### PR TITLE
Fix Mobile Styling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: `What does it take to decarbonize your state?`,
+    title: 'What does it take to decarbonize your state?',
     description: ``,
     author: `Chi Hack Night`,
     url: `https://state-decarbonize.netlify.app`,

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -119,9 +119,9 @@ const ChoroplethMap = ({emissions, sidebar = true, selected_location = {}}) => {
       <div style={tooltipStyle}>
         <CustomHover emissions={emissions} activeRegion={activeRegion}/>
       </div>
-      <Row>
+      <Row className="map-row">
         {emissions && sidebar ?
-          <Col lg={3}>
+          <Col lg={3} className="map-legend">
             <div className="h6 mt-5 mb-3 font-weight-bold">
               Million metric tons of carbon dioxide equivalent (MMTCO2e) emissions in 2018
             </div>

--- a/src/components/simpleareachart.js
+++ b/src/components/simpleareachart.js
@@ -35,7 +35,7 @@ export default function SimpleAreaChart ({emissions_data}) {
   var data = annualhistoricalEmissions.concat(projection)
  
   return (
-    <ResponsiveContainer width="100%" height={500}>
+    <ResponsiveContainer className="simplearea-cont">
       <AreaChart
         width={800}
         height={400}
@@ -61,6 +61,7 @@ export default function SimpleAreaChart ({emissions_data}) {
           stroke="#b65c00"
           fill="#e8ceb3"
           name="Emissions"
+          isAnimationActive={false}
         />
         <Area
           type="monotone"
@@ -69,6 +70,7 @@ export default function SimpleAreaChart ({emissions_data}) {
           stroke="#36a654"
           fill="#c1e5cb"
           name="Projection"
+          isAnimationActive={false}
         />
         <ReferenceLine x="2018" stroke="none" label={{value:"Emissions", angle:90, fill:"#b65c00"}} />
         <ReferenceLine x="2024" stroke="none" label={{value:"Projections", angle:90, fill:"#36a654"}} />

--- a/src/components/singlebar.js
+++ b/src/components/singlebar.js
@@ -63,7 +63,7 @@ export default function SingleBarChart ({ emissionsData, homeView, mobileView, a
   const BarsConfig = {
     other: {
       key: 'dumps_farms_industrial_other',
-      text: '🏭 Farms, Industrial & Other:',
+      text: '🏭 Farms, Industry & Other:',
       fill: '#ad8669',
       // This category cannot be electrified so make the greenFill red to be
       // clearly bad
@@ -93,13 +93,13 @@ export default function SingleBarChart ({ emissionsData, homeView, mobileView, a
   let LabelPosition = 'right'
   let GraphMargin = {
     top: 10,
-    right: 200,
+    right: 125,
     left: 0,
     bottom: 0
   }
 
   BarWidth = 150
-  GraphWidth = 400
+  GraphWidth = 300
   GraphHeight = 350
 
   // Apply custom styling with interior labels for homepage chart

--- a/src/components/singlebar.js
+++ b/src/components/singlebar.js
@@ -6,7 +6,7 @@ const getPct = (value, total) => { return Math.round((value/total)*100) }
 
 /** Create the label text with the percentage */
 const getLabel = (entry, total, field, label) => {
-  return `${label}: ${getPct(entry[field], total)}%`
+  return `${label} ${getPct(entry[field], total)}%`
 }
 
 /**
@@ -15,6 +15,7 @@ const getLabel = (entry, total, field, label) => {
 let BarWidth
 let GraphWidth
 let GraphHeight
+let LineWidth = 50
 
 /**
  * A vertically stacked bar chart intended to show the groups of different
@@ -41,7 +42,7 @@ let GraphHeight
  * @param {Array<string>} greenKeys Optional array of keys to show in green,
  * indicating they have been electrified.
  */
-export default function SingleBarChart ({ emissionsData, homeView, activeKey, greenKeys }) {
+export default function SingleBarChart ({ emissionsData, homeView, mobileView, activeKey, greenKeys }) {
   // sum all emissions fields except year
   const emissionsTotal = Object.entries(emissionsData)
     .filter(([key,_val]) => key !== 'year')
@@ -62,7 +63,7 @@ export default function SingleBarChart ({ emissionsData, homeView, activeKey, gr
   const BarsConfig = {
     other: {
       key: 'dumps_farms_industrial_other',
-      text: '🏭 Farms, Industrial & Other',
+      text: '🏭 Farms, Industrial & Other:',
       fill: '#ad8669',
       // This category cannot be electrified so make the greenFill red to be
       // clearly bad
@@ -70,25 +71,25 @@ export default function SingleBarChart ({ emissionsData, homeView, activeKey, gr
     },
     transport: {
       key: 'transportation',
-      text: '🚗 Transportation',
+      text: '🚗 Transportation:',
       fill: '#c2c2c2',
       greenFill: '#6ebf70',
     },
     buildings: {
       key: 'buildings',
-      text: '🏠 Buildings',
+      text: '🏠 Buildings:',
       fill: '#dcdcdc',
       greenFill: '#a3d7a4',
     },
     power: {
       key: 'dirty_power',
-      text: '🔌 Dirty Power',
+      text: '🔌 Dirty Power:',
       fill: '#a6a6a6',
       greenFill: '#4caf50',
     }
   }
 
-  const LabelOffset = 12
+  let LabelOffset = 12
   let LabelPosition = 'right'
   let GraphMargin = {
     top: 10,
@@ -112,14 +113,28 @@ export default function SingleBarChart ({ emissionsData, homeView, activeKey, gr
       left: 0,
       bottom: 0
     }
-  }
 
+    // On mobile homeView use short text and smaller graph
+    if (mobileView) {
+      BarsConfig.power.text = 'Power'
+      BarsConfig.buildings.text = 'Buildings'
+      BarsConfig.transport.text = 'Transport'
+      BarsConfig.other.text = 'Other'
+      BarWidth = 30
+      GraphWidth = 150
+      GraphHeight = 300
+      LabelOffset = 8
+      LineWidth = 15
+      LabelPosition = 'left'
+      GraphMargin.left = 110
+    }
+  }
   // If on state details, shorten text labels
-  if (!homeView) {
-    BarsConfig.power.text = '🔌 Power'
-    BarsConfig.buildings.text = '🏠 Buildings'
-    BarsConfig.transport.text = '🚗 Transport'
-    BarsConfig.other.text = '🏭 Other'
+  else {
+    BarsConfig.power.text = '🔌 Power:'
+    BarsConfig.buildings.text = '🏠 Buildings:'
+    BarsConfig.transport.text = '🚗 Transport:'
+    BarsConfig.other.text = '🏭 Other:'
   }
 
   // If greenKeys are specified, switch those bars' fill to their greenFill color
@@ -215,7 +230,9 @@ export default function SingleBarChart ({ emissionsData, homeView, activeKey, gr
         <ReferenceArea shape={
           <ElectrificationLines
             electrificationPrcnt={electrificationPrcnt}
-            homeView={homeView} />
+            graphMargin={GraphMargin}
+            homeView={homeView}
+            lineWidth={LineWidth} />
         }/>
       </BarChart>
     </div>
@@ -232,31 +249,30 @@ export default function SingleBarChart ({ emissionsData, homeView, activeKey, gr
  * 3. A vertical line connecting the right endpoints of #1 and #2
  * 4. A horizontal line going right from the center point of #3
  */
-function ElectrificationLines ({ electrificationPrcnt, homeView }) {
+function ElectrificationLines ({ electrificationPrcnt, homeView, lineWidth, graphMargin }) {
   if (!homeView) {
     return null
   }
 
-  const LineWidth = 50
-
   const StrokeWidth = 4
+  const LeftX = BarWidth + graphMargin.left * 0.75
   const TopY = StrokeWidth
   const BotY = GraphHeight * (electrificationPrcnt / 100)
 
   const lines = [
-    { x1: BarWidth, x2: BarWidth + LineWidth, y1: TopY, y2: TopY },
-    { x1: BarWidth, x2: BarWidth + LineWidth, y1: BotY, y2: BotY },
+    { x1: LeftX, x2: LeftX + LineWidth, y1: TopY, y2: TopY },
+    { x1: LeftX, x2: LeftX + LineWidth, y1: BotY, y2: BotY },
     // The vertical line
     {
-      x1: BarWidth + LineWidth - StrokeWidth/2,
-      x2: BarWidth + LineWidth - StrokeWidth/2,
+      x1: LeftX + LineWidth - StrokeWidth/2,
+      x2: LeftX + LineWidth - StrokeWidth/2,
       y1: TopY,
       y2: BotY
     },
     // The right mid line
     {
-      x1: BarWidth + LineWidth,
-      x2: BarWidth + LineWidth * 2,
+      x1: LeftX + LineWidth - StrokeWidth,
+      x2: LeftX + LineWidth - StrokeWidth + LineWidth,
       y1: BotY / 2,
       y2: BotY / 2,
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -123,15 +123,15 @@ const IndexPage = ({data}) => {
   )
 }
 
-function StatesList({ stateSlugs }) {
+function StatesList ({ stateSlugs }) {
   // Sort slugs A-Z
-  stateSlugs.sort();
+  stateSlugs.sort()
 
-  function slugToTitle(slug) {
+  function slugToTitle (slug) {
     return slug
       .replaceAll('_', ' ')
       // .replace(/_/g, ' ')
-      .replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+      .replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase())
   }
 
   return (
@@ -145,7 +145,7 @@ function StatesList({ stateSlugs }) {
         )
       }
     </ul>
-    )
+  )
 }
 
 export default IndexPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,10 +76,17 @@ const IndexPage = ({data}) => {
         To do that (and solve the climate crisis) there's one main thing
       </p>
 
-      <div className="d-flex justify-content-center mt-7">
-        <SingleBarChart emissionsData={barChartData} homeView={true} />
+      <div className="electrication-cont d-flex justify-content-center mt-7">
+        {/* Desktop only graph */}
+        <div className="d-none d-md-block">
+          <SingleBarChart emissionsData={barChartData} homeView={true} />
+        </div>
+        {/* Mobile only graph */}
+        <div className="d-md-none">
+          <SingleBarChart emissionsData={barChartData} homeView={true} mobileView={true} />
+        </div>
 
-        <div className="ml-5">
+        <div className="ml-3 ml-md-5">
           <p className="h1 font-weight-boldest mt-6 mb-7">
             Clean <br/> Electrification!
           </p>
@@ -88,13 +95,13 @@ const IndexPage = ({data}) => {
         </div>
       </div>
 
-      <p className="h1 text-center mt-7 font-weight-bold">
+      <p className="h1 text-center mt-8 font-weight-bold">
         The levers of change are at the
         state level, <br className="d-none d-lg-block" />
         and each state is different.
       </p>
 
-      <p className="text-center mt-2 mb-7">
+      <p className="text-center mt-5 mb-5">
         Click on your state to see what it takes to decarbonize by 2050
       </p>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,7 +65,11 @@ const IndexPage = ({data}) => {
         2050, the US must <br className="d-none d-lg-block" />
         cut climate pollution by <strong>{cutPerYearPrcnt}% a year.</strong>
       </p>
-      Total US climate pollution
+
+      <h2 className="h4 font-weight-bold">Total US Emissions</h2>
+      <p className="h6">
+        Million metric tons of CO<sub>2</sub> equivalent (MMTCO2e) emissions
+      </p>
       <SimpleAreaChart emissions_data={emissionsOverTime}/>
 
       <p className='h2 text-center mt-7 mb-5'>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -37,6 +37,10 @@ const IndexPage = ({data}) => {
   // Prep data for choropleth map
   const mapData = getLatestEmissions(cleanData)
 
+  const stateSlugs = Object.keys(mapData)
+
+  console.log('stateSlugs', stateSlugs)
+
   // TODO: Extract currentYear and cutPerYearPrcnt to common place
   const currentYear = new Date().getFullYear()
 
@@ -108,8 +112,40 @@ const IndexPage = ({data}) => {
       <div className="mb-md-5">
         <ChoroplethMap emissions={mapData} />
       </div>
+
+      {/* Show list of states on mobile */}
+      <div className="d-lg-none">
+        <h2 className="h4 font-weight-bold mt-5 mb-3">Browse by State</h2>
+
+        <StatesList stateSlugs={stateSlugs}/>
+      </div>
     </Layout>
   )
+}
+
+function StatesList({ stateSlugs }) {
+  // Sort slugs A-Z
+  stateSlugs.sort();
+
+  function slugToTitle(slug) {
+    return slug
+      .replaceAll('_', ' ')
+      // .replace(/_/g, ' ')
+      .replace(/\w\S*/g, txt => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+  }
+
+  return (
+    <ul className="state-links">
+      {
+        stateSlugs.map(slug =>
+          <li>
+            <a href={`/${slug}`}
+              className="btn btn-light">{slugToTitle(slug)}</a>
+          </li>
+        )
+      }
+    </ul>
+    )
 }
 
 export default IndexPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -60,7 +60,7 @@ const IndexPage = ({data}) => {
 
       <hr></hr>
 
-      <p className="h1 mt-5 mb-5 text-center">
+      <p className="h1 mt-6 mb-5 text-center main-phrase">
         To get to <strong>zero</strong> by
         2050, the US must <br className="d-none d-lg-block" />
         cut climate pollution by <strong>{cutPerYearPrcnt}% a year.</strong>
@@ -95,7 +95,7 @@ const IndexPage = ({data}) => {
         </div>
       </div>
 
-      <p className="h1 text-center mt-8 font-weight-bold">
+      <p className="h1 text-center mt-8 font-weight-bold main-phrase">
         The levers of change are at the
         state level, <br className="d-none d-lg-block" />
         and each state is different.
@@ -105,7 +105,7 @@ const IndexPage = ({data}) => {
         Click on your state to see what it takes to decarbonize by 2050
       </p>
 
-      <div className="mb-7">
+      <div className="mb-md-5">
         <ChoroplethMap emissions={mapData} />
       </div>
     </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,8 +39,6 @@ const IndexPage = ({data}) => {
 
   const stateSlugs = Object.keys(mapData)
 
-  console.log('stateSlugs', stateSlugs)
-
   // TODO: Extract currentYear and cutPerYearPrcnt to common place
   const currentYear = new Date().getFullYear()
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -159,6 +159,8 @@ footer {
     background-color: #f3f3f3;
 }
 
+.electrication-cont .h1 { font-size: 1.5rem; }
+.electrication-cont .h3 { font-size: 1rem; }
 
 /**
  * Styling for the sticky graph container
@@ -207,6 +209,12 @@ footer {
     transition: fill 0.4s;
 }
 
+@media (max-width: 991px) {
+    .single-bar-chart tspan {
+        font-size: 0.8rem;
+    }
+}
+
 /**
  * ChoroplethMap Styling
  */
@@ -217,8 +225,6 @@ footer {
 
     .map-row .map-legend { max-width: 25rem; }
 }
-
-
 
 /**
  * State Details Page - full desktop sticky graph layout

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -151,6 +151,18 @@ footer { text-align: center; }
     background-color: #f3f3f3;
 }
 
+.state-links {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    list-style: none;
+    padding: 0;
+    gap: 15px;
+}
+
+/* Darken buttons a touch for state links */
+.state-links .btn-light { background-color: #eff0f1; }
+
 /**
  * Styling for the sticky graph container
  */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,9 +33,17 @@ body {
  */
 .font-weight-boldest { font-weight: 900; }
 
+/**
+ * Homepage main header styling
+ */
 .main-header {
-    margin-top: 10rem;
-    margin-bottom: 10rem;
+    margin: 10rem 0;
+}
+
+@media (max-width: 575px) {
+    .main-header { margin: 5rem 0; }
+    .main-header h1 { font-size: 2rem !important; }
+    .main-header .h3 { font-size: 1.25rem !important; }
 }
 
 .page-item.active .page-link {
@@ -159,8 +167,10 @@ footer {
     background-color: #f3f3f3;
 }
 
-.electrication-cont .h1 { font-size: 1.5rem; }
-.electrication-cont .h3 { font-size: 1rem; }
+@media (max-width: 575px) {
+    .electrication-cont .h1 { font-size: 1.5rem; }
+    .electrication-cont .h3 { font-size: 1rem; }
+}
 
 /**
  * Styling for the sticky graph container
@@ -194,7 +204,6 @@ footer {
     .simplearea-cont tspan { font-size:12px; }
 }
 
-
 /**
  * SingleBarChart styling
  */
@@ -210,9 +219,7 @@ footer {
 }
 
 @media (max-width: 991px) {
-    .single-bar-chart tspan {
-        font-size: 0.8rem;
-    }
+    .single-bar-chart tspan { font-size: 0.8rem; }
 }
 
 /**

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 /* Import stateface for state icons */
 @import 'stateface/stateface.css';
+@import 'index.css';
 
 /** Import Lato Google font with specific weights */
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,500;0,700;0,900;1,400&display=swap');
@@ -33,27 +34,12 @@ body {
  */
 .font-weight-boldest { font-weight: 900; }
 
-/**
- * Homepage main header styling
- */
-.main-header {
-    margin: 10rem 0;
-}
-
-@media (max-width: 575px) {
-    .main-header { margin: 5rem 0; }
-    .main-header h1 { font-size: 2rem !important; }
-    .main-header .h3 { font-size: 1.25rem !important; }
-}
-
 .page-item.active .page-link {
     background-color: var(--brand-color);
     border-color: var(--brand-color);
 }
 
-.float-right {
-    text-align: right;
-}
+.float-right { text-align: right; }
 
 .recharts-cartesian-axis-tick {
     font-size: 0.8rem;
@@ -151,9 +137,7 @@ path:focus, .mapSelected {
     border-top: 1px solid #dee2e6;
 }
 
-footer {
-    text-align: center;
-}
+footer { text-align: center; }
 
 .custom-tooltip {
     background-color: white;
@@ -165,11 +149,6 @@ footer {
     padding: 2rem;
     margin:  5rem 0;
     background-color: #f3f3f3;
-}
-
-@media (max-width: 575px) {
-    .electrication-cont .h1 { font-size: 1.5rem; }
-    .electrication-cont .h3 { font-size: 1rem; }
 }
 
 /**
@@ -220,17 +199,6 @@ footer {
 
 @media (max-width: 991px) {
     .single-bar-chart tspan { font-size: 0.8rem; }
-}
-
-/**
- * ChoroplethMap Styling
- */
-
-/** Mobile - move leged below the map */
-@media (max-width: 991px) {
-    .map-row { flex-direction: column-reverse; }
-
-    .map-row .map-legend { max-width: 25rem; }
 }
 
 /**

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -112,8 +112,8 @@ path:focus, .mapSelected {
 }
 
 #frames {
-  fill: none;
-  stroke: grey;
+    fill: none;
+    stroke: grey;
 }
 
 .sunrise-green {
@@ -124,11 +124,15 @@ path:focus, .mapSelected {
     border-bottom: 1px solid #aaaaaa;
 }
 
+
+/** Style header title */
 .nav-text {
     text-decoration: none;
     text-transform: capitalize;
     font-weight: bold;
     color: #000000;
+    /* Make sure we always have room for mobile menu */
+    max-width: calc(100% - 80px);
 }
 
 .table-bordered, .table-bordered td, .table-bordered th {
@@ -172,6 +176,24 @@ footer {
 }
 
 /**
+ * SimpleAreaChart styling
+ */
+.simplearea-cont {
+    height: auto !important;
+    aspect-ratio: 2/1;
+}
+
+.simplearea-cont tspan { font-weight: bold; }
+
+/* Mobile styling Make graph taller aspect ratio on mobile screens and shrink labels */
+@media (max-width: 575px) {
+    .simplearea-cont { aspect-ratio: 1.5/1; }
+
+    .simplearea-cont tspan { font-size:12px; }
+}
+
+
+/**
  * SingleBarChart styling
  */
 .single-bar-chart text {
@@ -184,6 +206,19 @@ footer {
 .single-bar-chart .recharts-rectangle {
     transition: fill 0.4s;
 }
+
+/**
+ * ChoroplethMap Styling
+ */
+
+/** Mobile - move leged below the map */
+@media (max-width: 991px) {
+    .map-row { flex-direction: column-reverse; }
+
+    .map-row .map-legend { max-width: 25rem; }
+}
+
+
 
 /**
  * State Details Page - full desktop sticky graph layout

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,30 @@
+/**
+ * Homepage styles
+ *
+ * Warning: This styling is ultimately applied to the global scope!
+ */
+
+
+.main-header { margin: 10rem 0; }
+
+/** Tablet & mobile - move legend below the map */
+@media (max-width: 991px) {
+    .map-row { flex-direction: column-reverse; }
+    .map-row .map-legend { max-width: 25rem; }
+}
+
+@media (max-width: 575px) {
+    .main-header { margin: 5rem 0; }
+    .main-header h1 { font-size: 2rem !important; }
+    .main-header .h3 { font-size: 1.25rem !important; }
+
+    .main-phrase {
+      font-size: 2rem;
+      text-align: left !important;
+    }
+
+    .electrication-cont .h1 { font-size: 1.5rem; }
+    .electrication-cont .h3 { font-size: 1rem; }
+}
+
+


### PR DESCRIPTION
## Overview

Fixes mobile issues on the homepage and state details pages by making sure all graphs scale down to mobile properly and scaling a few large pieces of text.

<details>
  <summary>Comparison</summary>

  | Before | After |
  | --- | --- |
  | ![state-decarbonize netlify app_(iPhone SE) (2)](https://user-images.githubusercontent.com/3187531/164149143-c2b29342-e151-47c7-9093-547f19c4f808.png) | ![localhost_8000_(iPhone SE)](https://user-images.githubusercontent.com/3187531/164149140-70badba2-d78f-457f-8699-b19d272e811c.png) |

</details>

Closes #54.

### Demo

See description.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Test on mobile, tablet, and desktop
* Also make sure to drag around the width to confirm there's no views at which things look atrocious
* **Note:** Graphs often don't resize properly until refresh, I don't know if it's worth doing a bunch of JS recalculations on resize but if that would be ideal I can toss that in