### PR TITLE
graph is smooth

### DIFF
--- a/src/components/simpleareachart.js
+++ b/src/components/simpleareachart.js
@@ -11,7 +11,7 @@ import {
   Label
 } from "recharts"
 
-export default function SimpleAreaChart ({emissions_data}) {
+export default function SimpleAreaChart ({ emissions_data }) {
 
   const annualhistoricalEmissions = emissions_data.map((item) => {
     var data = { year: item.year, hist: 0 }
@@ -29,11 +29,15 @@ export default function SimpleAreaChart ({emissions_data}) {
 
   for (let step = 0; step < (yearsLeft + 1); step++) {
     if (step === 0) { projection.push({ year: currYear, hist: reduceFrom, projected: reduceFrom }) }
-    else { projection.push({ year: step + currYear, projected: Math.round(reduceFrom - reduceFrom * step / yearsLeft)}) }
+    else {
+      var rounded = (Math.round((reduceFrom - reduceFrom * step / yearsLeft) * 100)) / 100
+      if (rounded < 0) { rounded = 0 }
+      projection.push({ year: step + currYear, projected: rounded })
+    }
   }
 
   var data = annualhistoricalEmissions.concat(projection)
- 
+
   return (
     <ResponsiveContainer className="simplearea-cont">
       <AreaChart
@@ -50,7 +54,7 @@ export default function SimpleAreaChart ({emissions_data}) {
         {/* <Legend align="center" verticalAlign="top" iconType="square" iconSize="15" /> */}
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis dataKey="year" >
-          <Label value="Year" offset={-15} position="insideBottom"/>
+          <Label value="Year" offset={-15} position="insideBottom" />
         </XAxis>
         <YAxis />
         <Tooltip />
@@ -72,8 +76,8 @@ export default function SimpleAreaChart ({emissions_data}) {
           name="Projection"
           isAnimationActive={false}
         />
-        <ReferenceLine x="2018" stroke="none" label={{value:"Emissions", angle:90, fill:"#b65c00"}} />
-        <ReferenceLine x="2024" stroke="none" label={{value:"Projections", angle:90, fill:"#36a654"}} />
+        <ReferenceLine x="2018" stroke="none" label={{ value: "Emissions", angle: 90, fill: "#b65c00" }} />
+        <ReferenceLine x="2024" stroke="none" label={{ value: "Projections", angle: 90, fill: "#36a654" }} />
       </AreaChart>
     </ResponsiveContainer>
   )


### PR DESCRIPTION
## Overview
This PR solves the problem of bumpy graphs caused by rounding to the nearest whole integer.  The calculation is now set to calculate to the .01 which when graphed smooths out the bumps.

Closes #059
![Screenshot 2022-05-01 at 19-45-21 What does it take to decarbonize your state](https://user-images.githubusercontent.com/28713997/166172100-0d284520-c679-4a98-9bb1-fb7c2ee8be7d.png)


### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions
Visually inspect the state details graph for Maine to verify the graph is smooth.  Also check random states' graphs to verify no addition bugs have been introduced.