### PR TITLE
Make state tooltip nice and tabbable

### DIFF
--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -24,13 +24,13 @@ const CustomHover = ({ emissions, activeRegion }) => {
   }
 }
 
-function getActiveRegionFromElem(elem) {
+function getActiveRegionFromElem (elem) {
   const newActiveRegion = {
     id: elem.getAttribute("id"),
     name: elem.getAttribute("name")
   }
 
-  return newActiveRegion;
+  return newActiveRegion
 }
 
 const mouseOver = (event, setActiveRegion, setTooltipStyle) => {
@@ -55,34 +55,34 @@ const mouseOut = (event, setActiveRegion, setTooltipStyle) => {
   setTooltipStyle(newTooltipStyle)
 }
 
-function showTooltip(targetElem, setTooltipStyle) {
-  const targetRect = targetElem.getBoundingClientRect();
+function showTooltip (targetElem, setTooltipStyle) {
+  const targetRect = targetElem.getBoundingClientRect()
 
   // These two values are absolute, so they will move the tooltip the same
   // number of pixels for tiny states (like DC) and large ones (like Texas)
-  let tooltipYOffsetPx = 0;
-  let tooltipXOffsetPx = -2;
+  let tooltipYOffsetPx = 0
+  let tooltipXOffsetPx = -2
 
   // We subtract these from the coords to align by top center by default
-  const tooltipHeight = 62;
-  const tooltipWidth = 150;
+  const tooltipHeight = 62
+  const tooltipWidth = 150
 
-  const stateWidth = targetRect.width;
-  const stateHeight = targetRect.height;
+  const stateWidth = targetRect.width
+  const stateHeight = targetRect.height
 
-  const partialStateHeight = stateHeight * 0.3;
+  const partialStateHeight = stateHeight * 0.3
 
   // Move Florida's tooltip to the right relative to its width since it's center
   // is in the gulf
   if (targetElem.id === 'florida') {
-    tooltipXOffsetPx += stateWidth * 0.25;
+    tooltipXOffsetPx += stateWidth * 0.25
   }
 
-  const centerX = targetRect.x + (stateWidth / 2) - (tooltipWidth / 2);
-  const topY = targetRect.y - tooltipHeight;
+  const centerX = targetRect.x + (stateWidth / 2) - (tooltipWidth / 2)
+  const topY = targetRect.y - tooltipHeight
 
-  const x = centerX  - (stateWidth * 0.1) + tooltipXOffsetPx;
-  const y = topY  + partialStateHeight + tooltipYOffsetPx;
+  const x = centerX  - (stateWidth * 0.1) + tooltipXOffsetPx
+  const y = topY  + partialStateHeight + tooltipYOffsetPx
 
   const newTooltipStyle = {
     opacity: 1,
@@ -100,7 +100,7 @@ const focus = (event, setActiveRegion, setTooltipStyle) => {
   showTooltip(targetElem, setTooltipStyle)
 
   setActiveRegion(getActiveRegionFromElem(event.target))
-};
+}
 
 const handleClick = (event, activeRegion) => {
   navigate(`/${activeRegion.id}`)

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -6,7 +6,7 @@ import { navigate } from "gatsby"
 import USMap from "../images/svg/usaStatesNoTerritories.js"
 import jenks from "./jenks"
 
-function CustomHover({ emissions, activeRegion }) {
+function CustomHover ({ emissions, activeRegion }) {
   if (emissions[activeRegion.id] != null) {
     return (
       <>
@@ -33,7 +33,7 @@ function getActiveRegionFromElem (elem) {
   return newActiveRegion
 }
 
-function mouseOver(event, setActiveRegion, setTooltipStyle) {
+function mouseOver (event, setActiveRegion, setTooltipStyle) {
   const targetElem = event.target
 
   if(targetElem.id !== "frames") {
@@ -45,7 +45,7 @@ function mouseOver(event, setActiveRegion, setTooltipStyle) {
   showTooltip(targetElem, setTooltipStyle)
 }
 
-function mouseOut(event, setActiveRegion, setTooltipStyle) {
+function mouseOut (event, setActiveRegion, setTooltipStyle) {
   const targetElem = event.target
   targetElem.setAttribute("style", "")
 
@@ -91,11 +91,11 @@ function showTooltip (targetElem, setTooltipStyle) {
   setTooltipStyle(newTooltipStyle)
 }
 
-function hideTooltip(setTooltipStyle) {
+function hideTooltip (setTooltipStyle) {
   setTooltipStyle({ opacity: 0 })
 }
 
-function focus(event, setActiveRegion, setTooltipStyle) {
+function focus (event, setActiveRegion, setTooltipStyle) {
   const targetElem = event.target
 
   showTooltip(targetElem, setTooltipStyle)
@@ -103,15 +103,15 @@ function focus(event, setActiveRegion, setTooltipStyle) {
   setActiveRegion(getActiveRegionFromElem(event.target))
 }
 
-function blur(event, setTooltipStyle) {
+function blur (event, setTooltipStyle) {
   hideTooltip(setTooltipStyle)
 }
 
-function handleClick(event, activeRegion) {
+function handleClick (event, activeRegion) {
   navigate(`/${activeRegion.id}`)
 }
 
-function getBuckets(emissions, numBuckets) {
+function getBuckets (emissions, numBuckets) {
   const buckets = jenks(Object.values(emissions), numBuckets)
   return buckets
 }

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -6,7 +6,7 @@ import { navigate } from "gatsby"
 import USMap from "../images/svg/usaStatesNoTerritories.js"
 import jenks from "./jenks"
 
-const CustomHover = ({ emissions, activeRegion }) => {
+function CustomHover({ emissions, activeRegion }) {
   if (emissions[activeRegion.id] != null) {
     return (
       <>
@@ -33,7 +33,7 @@ function getActiveRegionFromElem (elem) {
   return newActiveRegion
 }
 
-const mouseOver = (event, setActiveRegion, setTooltipStyle) => {
+function mouseOver(event, setActiveRegion, setTooltipStyle) {
   const targetElem = event.target
 
   if(targetElem.id !== "frames") {
@@ -45,14 +45,12 @@ const mouseOver = (event, setActiveRegion, setTooltipStyle) => {
   showTooltip(targetElem, setTooltipStyle)
 }
 
-const mouseOut = (event, setActiveRegion, setTooltipStyle) => {
+function mouseOut(event, setActiveRegion, setTooltipStyle) {
   const targetElem = event.target
   targetElem.setAttribute("style", "")
 
-  const newTooltipStyle = { opacity: 0 }
-
   setActiveRegion(getActiveRegionFromElem(targetElem))
-  setTooltipStyle(newTooltipStyle)
+  hideTooltip(setTooltipStyle)
 }
 
 function showTooltip (targetElem, setTooltipStyle) {
@@ -93,20 +91,27 @@ function showTooltip (targetElem, setTooltipStyle) {
   setTooltipStyle(newTooltipStyle)
 }
 
-const focus = (event, setActiveRegion, setTooltipStyle) => {
-  const targetElem = event.target
+function hideTooltip(setTooltipStyle) {
+  setTooltipStyle({ opacity: 0 })
+}
 
+function focus(event, setActiveRegion, setTooltipStyle) {
+  const targetElem = event.target
 
   showTooltip(targetElem, setTooltipStyle)
 
   setActiveRegion(getActiveRegionFromElem(event.target))
 }
 
-const handleClick = (event, activeRegion) => {
+function blur(event, setTooltipStyle) {
+  hideTooltip(setTooltipStyle)
+}
+
+function handleClick(event, activeRegion) {
   navigate(`/${activeRegion.id}`)
 }
 
-const getBuckets = (emissions, numBuckets) => {
+function getBuckets(emissions, numBuckets) {
   const buckets = jenks(Object.values(emissions), numBuckets)
   return buckets
 }
@@ -203,6 +208,7 @@ const ChoroplethMap = ({emissions, sidebar = true, selected_location = {}}) => {
             onLocationFocus={(e) => {focus(e, setActiveRegion, setTooltipStyle)}}
             onLocationMouseOver={(e) => {mouseOver(e, setActiveRegion, setTooltipStyle)}}
             onLocationMouseOut={(e) => {mouseOut(e, setActiveRegion, setTooltipStyle)}}
+            onLocationBlur={(e) => {blur(e, setTooltipStyle)}}
             onLocationClick={(e) => {handleClick(e, activeRegion)}}
           />
         </Col>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -136,7 +136,7 @@ function StatesList ({ stateSlugs }) {
     <ul className="state-links">
       {
         stateSlugs.map(slug =>
-          <li>
+          <li key={slug}>
             <a href={`/${slug}`}
               className="btn btn-light">{slugToTitle(slug)}</a>
           </li>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,6 +13,10 @@ body, * {
     font-family: 'Lato', sans-serif;
 }
 
+body *:focus {
+    outline: dashed 0.25rem #993404;
+}
+
 body {
     background-color: #FFFFFB;
     font-family: "Source Serif Pro",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
@@ -77,10 +81,29 @@ body {
     background: #aaa;
 }
 
-/* Style focused <path> elements or selected state */
+.map-tooltip {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 5;
+    /* Disable mouse events to prevent hovering tooltip hiding it */
+    pointer-events: none;
+}
+
+.map-tooltip .arrow { left:  48%; }
+
+.map-tooltip .tooltip-inner { width: 150px; }
+
+
+/**
+ * Style focused <path> elements with border and darkening
+ */
 path:focus, .mapSelected {
     stroke: #421B49;
-    stroke-width: 4;
+    stroke-width: 3;
+    outline: none;
+    filter:  brightness(0.75);
 }
 
 .legendKey {


### PR DESCRIPTION
## Overview

Makes it so the map of states on the homepage uses a Bootstrap tooltip and is now tabbable and shows the tooltip. Here's a little demo, starting with tabbing and then moving to using the mouse:

https://user-images.githubusercontent.com/3187531/167757160-03dd37bb-dd6e-43b4-bffa-7d791ac9c675.mp4

Closes #78

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Try tabbing through the map and confirm you see the tooltips
* Hover over the map and confirm you see reasonable tooltipss