### PR TITLE
accessibility: increase contrast on navbar and action-panel links

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -157,6 +157,11 @@ path:focus, .mapSelected {
     max-width: calc(100% - 80px);
 }
 
+#responsive-navbar-nav > div > a {
+    color: rgba(0, 0, 0, .7);
+}
+
+
 .table-bordered, .table-bordered td, .table-bordered th {
     border: none;
 }
@@ -165,7 +170,13 @@ path:focus, .mapSelected {
     border-top: 1px solid #dee2e6;
 }
 
-footer { text-align: center; }
+footer { 
+    text-align: center; 
+}
+
+footer a { 
+    color: #004da1;
+}
 
 .custom-tooltip {
     background-color: #fff;
@@ -177,6 +188,10 @@ footer { text-align: center; }
     padding: 2rem;
     margin:  5rem 0;
     background-color: #f3f3f3;
+}
+
+.action-panel a {
+    color: #004da1;
 }
 
 .state-links {
@@ -284,17 +299,4 @@ footer { text-align: center; }
     }
 
      { opacity: 1 !important; }
-}
-
-/* Increase contrast for navbar and action-panel links. */
-#___gatsby .navbar-nav .nav-link {
-    color: rgba(0, 0, 0, .7);
-}
-
-#gatsby-focus-wrapper > footer a {
-    color: #004da1;
-}
-
-.action-panel a {
-    color: #004da1;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -262,3 +262,16 @@ footer { text-align: center; }
 
      { opacity: 1 !important; }
 }
+
+/* Increase contrast for navbar and action-panel links. */
+#___gatsby .navbar-nav .nav-link {
+    color: rgba(0, 0, 0, .7);
+}
+
+#gatsby-focus-wrapper > footer a {
+    color: #004da1;
+}
+
+.action-panel a {
+    color: #004da1;
+}


### PR DESCRIPTION
## Overview

Increase contrast on navbar and action-panel links for accessibility.

Closes #77 

I have made links in the following places less transparent, increasing the contrast.
![image](https://user-images.githubusercontent.com/27985352/168938015-f17f679c-34f5-4cf4-ab73-0283a069fce3.png)
![image](https://user-images.githubusercontent.com/27985352/168938061-50c50b6d-e3f6-4f3a-8ba3-4176da81c4d1.png)
![image](https://user-images.githubusercontent.com/27985352/168938101-1c3c0c61-8b95-4fee-8bc7-d52b8b7f495f.png)

axeDevTools no longer reports accessibility issues with the links when the full-site scan is run.

![image](https://user-images.githubusercontent.com/27985352/168941355-00e35113-3cd3-4956-9a7e-651ba5d14be5.png)
