### PR TITLE
Accessibility Fixes 2 - Fix Homepage Map Keyboard Use & Add Skip to Main Link 

### DIFF
--- a/src/components/AlreadyElectrifiedChart.js
+++ b/src/components/AlreadyElectrifiedChart.js
@@ -10,7 +10,6 @@ const AlreadyElectrifiedChart = ({ label, electrifiedPct, fossilPct }) => { //ot
         height="50px"
         style={{marginTop:'0.5em'}}
         xmlns="http://www.w3.org/2000/svg"
-        aria-labelledby={`${label}-title ${label}-description`}
         role="img"
       >
         <title id={`${label}-title`}>Percent of {label} electrified</title>

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -107,8 +107,18 @@ function blur (event, setTooltipStyle) {
   hideTooltip(setTooltipStyle)
 }
 
+/**
+ * Handles clicking or pressing enter after tabbing into a state, navigating
+ * to that state
+ */
 function handleClick (event, activeRegion) {
   navigate(`/${activeRegion.id}`)
+}
+
+function handleKeydown (event, activeRegion) {
+  if (event.key === 'Enter') {
+    handleClick(null, activeRegion)
+  }
 }
 
 function getBuckets (emissions, numBuckets) {
@@ -210,6 +220,7 @@ const ChoroplethMap = ({emissions, sidebar = true, selected_location = {}}) => {
             onLocationMouseOut={(e) => {mouseOut(e, setActiveRegion, setTooltipStyle)}}
             onLocationBlur={(e) => {blur(e, setTooltipStyle)}}
             onLocationClick={(e) => {handleClick(e, activeRegion)}}
+            onLocationKeyDown={(e) => {handleKeydown(e, activeRegion)}}
           />
         </Col>
       </Row>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -12,6 +12,9 @@ const Header = ({ siteTitle }) => (
       marginBottom: `1.45rem`
     }}
   >
+    <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
+      Skip to main content
+    </a>
     <Link className="nav-text text-body" to="/">{siteTitle}</Link>
     <Navbar.Toggle aria-controls="responsive-navbar-nav" />
     <Navbar.Collapse id="responsive-navbar-nav">

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -215,7 +215,7 @@ export default function StateDetailsPage ({ location, data }) {
       />
 
       <div className="sticky-header d-flex align-items-center">
-        <h1 className="d-flex align-items-center mr-4 mb-0">
+        <h1 id="main" className="d-flex align-items-center mr-4 mb-0">
           <span
             className={"display-3 mr-4 sf-" + stateFaceClass}
             aria-hidden="true"

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -6,7 +6,7 @@ import SEO from "../components/seo"
 const NotFoundPage = () => (
   <Layout>
     <SEO title="404: Not found" />
-    <h1>Page not found</h1>
+    <h1 id="main">Page not found</h1>
     <p>Try going back to the <Link to="/" >home page</Link>.</p>
   </Layout>
 )

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -10,7 +10,7 @@ const AboutPage = ({data, location}) => {
       <SEO title="About :: What does it take to decarbonize your state?" />
       <div className="container">
         <div className="border-bottom">
-          <h1 className="py-2" id="overview">Overview</h1>
+          <h1 id="main" className="py-2">Overview</h1>
           <p>About this app</p>
         </div>
       </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,7 +51,7 @@ const IndexPage = ({data}) => {
       <SEO title="What does it take to decarbonize your state?" />
 
       <div className="main-header">
-        <h1 className='display-4 text-center font-weight-bold'>
+        <h1 id="main" className='display-4 text-center font-weight-bold'>
           What does it take to <br className="d-none d-lg-block"/>
           decarbonize your state?
         </h1>

--- a/src/pages/terminology.js
+++ b/src/pages/terminology.js
@@ -8,7 +8,7 @@ const Terminology = () => {
     <Layout>
       <SEO title="Terminology" />
       <div className="container">
-        <h1 className="py-2">Terminology</h1>
+        <h1 id="main" className="py-2">Terminology</h1>
       </div>
     </Layout>
   )

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,9 +11,15 @@
 
 body, * {
     font-family: 'Lato', sans-serif;
+    /* Make sure anchors (like the skip to main) account for sticky header */
+    scroll-margin-top: 5rem;
 }
 
 body *:focus {
+    outline: dashed 0.25rem #993404;
+}
+
+.btn:focus {
     outline: dashed 0.25rem #993404;
 }
 
@@ -146,7 +152,6 @@ path:focus, .mapSelected {
     z-index: 100;
 }
 
-
 /** Style header title */
 .nav-text {
     text-decoration: none;
@@ -155,6 +160,12 @@ path:focus, .mapSelected {
     color: #000000;
     /* Make sure we always have room for mobile menu */
     max-width: calc(100% - 80px);
+}
+
+.skip-link:focus {
+    position: absolute;
+    padding: 0.5rem 1rem;
+    top: 0;
 }
 
 .table-bordered, .table-bordered td, .table-bordered th {


### PR DESCRIPTION
## Overview

Fixes some last accessibility issues, in particular:

1. Not being able to use the map on the homepage to navigate with just the keyboard (it was tabbable, but hitting Enter didn't navigate)
2. Not having a skip to main content link - you can now hit tab from the URL bar, hit Enter on the skip link, then hit tab to be on the first interactive element in the main content
3. Fixed a minor hold-over `aria-labelledby` attribute.

See the demo section for a better demo of the skip link.

This PR closes #91 and #90

### Demo

| Homepage Skip Demo | State Details Skip Demo |
| --- | --- |
| ![Peek 2022-05-17 20-38](https://user-images.githubusercontent.com/3187531/168939672-45576f53-06b9-44b4-a6ea-7bcee33930e0.gif) | ![Peek 2022-05-17 20-39](https://user-images.githubusercontent.com/3187531/168939669-01a1fa11-7df5-4f7a-895a-6dbd6a312761.gif) |

### Notes

None.

## Testing Instructions

* Test the skip link on **all pages** and confirm that if you hit tab you go to the next interactive element (sometimes the footer link if the page is empty)
* Test that you can use the homepage state map using just the keyboard - press Tab to get to the state you want, then press Enter to navigate to that state