### PR TITLE
Electricity generation electrification bar chart

### DIFF
--- a/src/components/AlreadyElectrifiedChart.js
+++ b/src/components/AlreadyElectrifiedChart.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 const electrifiedColor = "rgb(163, 215, 164)"
 const fossilColor = "rgb(255, 87, 34)"
-const AlreadyElectrifiedChart = ({ label, electrifiedPct, fossilPct }) => { //otherPct
+const AlreadyElectrifiedChart = ({ label, endLabel="Not yet", electrifiedPct, fossilPct }) => { //otherPct
   if (electrifiedPct !== 0 || fossilPct !== 0) {
     return (
       <svg
@@ -21,8 +21,8 @@ const AlreadyElectrifiedChart = ({ label, electrifiedPct, fossilPct }) => { //ot
         
         <rect x={0} y={'70%'} width={`${electrifiedPct}%`} height="30%" fill={electrifiedColor} />
         <rect x={`${electrifiedPct}%`} y={'70%'} width={`${fossilPct}%`} height="30%" fill={fossilColor} />
-        <text x={0} y={'40%'} fontSize="0.9rem" fontWeight="bold" alignmentBaseline='text-top'>{label} Electrified</text>
-        <text x={'100%'} y={'40%'} fontSize="0.9rem"  fontWeight="bold" textAnchor="end" alignmentBaseline='text-top'>Not yet</text>
+        <text x={0} y={'40%'} fontSize="0.9rem" fontWeight="bold" alignmentBaseline='text-top'>{label}</text>
+        <text x={'100%'} y={'40%'} fontSize="0.9rem"  fontWeight="bold" textAnchor="end" alignmentBaseline='text-top'>{endLabel}</text>
       </svg>
     )
   } else {

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -631,7 +631,8 @@ export default function StateDetailsPage ({ location, data }) {
               </p>
               
               <AlreadyElectrifiedChart
-                  label={"Non-Fossil Fuel Power Plants"}
+                  label={"Non-Fossil Fuel Electricity Generation"}
+                  endLabel={"Oil, Gas, and Coal Plants"}
                   electrifiedPct={pctCleanerPower}
                   fossilPct={pctFossilPower}
                 />

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -636,7 +636,7 @@ export default function StateDetailsPage ({ location, data }) {
                   fossilPct={pctFossilPower}
                 />
 
-              <p className="h4 mt-5 text-muted">[insert animated map here]</p>
+              {/* <p className="h4 mt-5 text-muted">[insert animated map here]</p> */}
             </div>
           )}
           {/* Show standard outro section if power emissions are zero */}

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -162,6 +162,24 @@ export default function StateDetailsPage ({ location, data }) {
     (plant) => plant.fossil_fuel_category === "OIL"
   )
 
+  const {
+    fossilPower,
+    cleanerPower
+  } = powerPlants.reduce((accumulator, entry) => {
+    if (['COAL','GAS','OIL'].includes(entry.fossil_fuel_category)) {
+      accumulator.fossilPower += entry.capacity_mw
+    } else {
+      accumulator.cleanerPower += entry.capacity_mw
+    }
+    return accumulator
+  },{
+    fossilPower: 0,
+    cleanerPower: 0
+  })
+
+  const pctFossilPower = Math.round((fossilPower / (fossilPower + cleanerPower)) * 100 * 10) / 10
+  const pctCleanerPower = Math.round((cleanerPower / (fossilPower + cleanerPower)) * 100 * 10) / 10
+
   function scrollTargetUpdated (scrollTarget) {
     let activeKey = "buildings"
     let greenKeys = []
@@ -611,6 +629,12 @@ export default function StateDetailsPage ({ location, data }) {
                 buildings we need to BUILD ? wind and solar farms. <br />
                 That's ? a year.
               </p>
+              
+              <AlreadyElectrifiedChart
+                  label={"Power Plants"}
+                  electrifiedPct={pctCleanerPower}
+                  fossilPct={pctFossilPower}
+                />
 
               <p className="h4 mt-5 text-muted">[insert animated map here]</p>
             </div>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -386,7 +386,7 @@ export default function StateDetailsPage ({ location, data }) {
               </p>
             )}
             <AlreadyElectrifiedChart
-              label={"Building Systems"}
+              label={"Building Systems Electrified"}
               electrifiedPct={weightedEleBuildingsPct}
               fossilPct={weightedFossilBuildingsPct}
             />
@@ -469,7 +469,7 @@ export default function StateDetailsPage ({ location, data }) {
                   % of the total).
                 </p>
                 <AlreadyElectrifiedChart
-                  label={"Vehicles"}
+                  label={"Vehicles Electrified"}
                   electrifiedPct={pctEv}
                   fossilPct={pctNonEv}
                 />
@@ -631,7 +631,7 @@ export default function StateDetailsPage ({ location, data }) {
               </p>
               
               <AlreadyElectrifiedChart
-                  label={"Power Plants"}
+                  label={"Non-Fossil Fuel Power Plants"}
                   electrifiedPct={pctCleanerPower}
                   fossilPct={pctFossilPower}
                 />


### PR DESCRIPTION
## Overview

This PR adds an already electrified chart for electricity generation by MW. I added logic to calculate the sum megawatts of strictly fossil plans (oil, gas, coal) and _cleaner_ plans (renewable, also includes biomass).

To clarify the text a bit I added a new parameter for the `AlreadyElectrifiedChart` component to customize the end label, so its a bit more cogent here:

Closes #68 

### Demo
![image](https://user-images.githubusercontent.com/10041771/168944188-04f3162f-e8de-4764-8388-abd085adba04.png)
Optional. Screenshots, `curl` examples, etc.

## Testing Instructions

* Go to state page