### PR TITLE
debug twitter social card

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ module.exports = {
     description: ``,
     author: `Chi Hack Night`,
     url: `https://decarbonizemystate.com/`,
-    image: `/socialcard.png`,
+    image: `socialcard.png`,
     siteName: "Decarbonize My State"
   },
   plugins: [

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -48,6 +48,7 @@ const SEO = ({ title, description, image, article }) => {
         <meta name="twitter:description" content={seo.description} />
       )}
       {seo.image && <meta name="twitter:image" content={seo.image} />}
+      {seo.image && <meta name="twitter:image:alt" content={seo.description} />}
       <meta name="twitter:site" content={siteName} />
       <meta name="twitter:url" content={seo.url} />
     </Helmet>


### PR DESCRIPTION
## Overview

Debugging the Twitter social card which is missing the image preview. Requires Netlify build to be deployed in order for card to be generated. Testing removing a "/" in the image url, and adding an image:alt tag.

## Resolves
This resolves issue #96

## Testing Instructions
To test, paste the link of the Netlify build here: 
https://cards-dev.twitter.com/validator
This is the fixed Twitter social card preview:
![image](https://user-images.githubusercontent.com/27985352/169932390-c46a4979-3b49-4172-bf68-341123591294.png)

There is no regression using the Facebook card validator:
![image](https://user-images.githubusercontent.com/27985352/169932337-272d9773-b35b-4430-86e0-d8f9d1f6a96c.png)
