### PR TITLE
Remove Empty Page Header Links and Add Beta Notice

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    title: 'What does it take to decarbonize your state?',
+    title: 'Decarbonize My State',
     description: ``,
     author: `Chi Hack Night`,
     url: `https://decarbonizemystate.com/`,

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -13,22 +13,20 @@ const Header = ({ siteTitle }) => (
         marginBottom: `1.45rem`
       }}
     >
-      <div className="container">
-        <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
-          Skip to main content
-        </a>
-        <Link className="nav-text text-body" to="/">{siteTitle}</Link>
-        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-        <Navbar.Collapse id="responsive-navbar-nav">
-          <Nav className="ml-auto">
-            <Link className="nav-link" to="/">Home</Link>
-            {/* Commented out for now since these pages are empty
-              <Link className="nav-link" to="/about">About</Link>
-              <Link className="nav-link" to="/terminology">Terminology</Link>
-            */}
-          </Nav>
-        </Navbar.Collapse>
-      </div>
+      <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
+        Skip to main content
+      </a>
+      <Link className="nav-text text-body" to="/">{siteTitle}</Link>
+      <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+      <Navbar.Collapse id="responsive-navbar-nav">
+        <Nav className="ml-auto">
+          <Link className="nav-link" to="/">Home</Link>
+          {/* Commented out for now since these pages are empty
+            <Link className="nav-link" to="/about">About</Link>
+            <Link className="nav-link" to="/terminology">Terminology</Link>
+          */}
+        </Nav>
+      </Navbar.Collapse>
     </Navbar>
     <div className="container">
       <div class=" alert alert-info ml-4 mr-4" role="alert">

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -13,24 +13,28 @@ const Header = ({ siteTitle }) => (
         marginBottom: `1.45rem`
       }}
     >
-      <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
-        Skip to main content
-      </a>
-      <Link className="nav-text text-body" to="/">{siteTitle}</Link>
-      <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-      <Navbar.Collapse id="responsive-navbar-nav">
-        <Nav className="ml-auto">
-          <Link className="nav-link" to="/">Home</Link>
-          {/* Commented out for now since these pages are empty
-            <Link className="nav-link" to="/about">About</Link>
-            <Link className="nav-link" to="/terminology">Terminology</Link>
-          */}
-        </Nav>
-      </Navbar.Collapse>
+      <div className="container">
+        <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
+          Skip to main content
+        </a>
+        <Link className="nav-text text-body" to="/">{siteTitle}</Link>
+        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+        <Navbar.Collapse id="responsive-navbar-nav">
+          <Nav className="ml-auto">
+            <Link className="nav-link" to="/">Home</Link>
+            {/* Commented out for now since these pages are empty
+              <Link className="nav-link" to="/about">About</Link>
+              <Link className="nav-link" to="/terminology">Terminology</Link>
+            */}
+          </Nav>
+        </Navbar.Collapse>
+      </div>
     </Navbar>
-    <div class="alert alert-info ml-4 mr-4" role="alert">
-      <strong>Decarbonize My State is in an open beta! </strong>
-      Some content may still be missing.
+    <div className="container">
+      <div class=" alert alert-info ml-4 mr-4" role="alert">
+        <strong>Decarbonize My State is in an open beta! </strong>
+        Some content or links may be missing.
+      </div>
     </div>
   </>
 )

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -4,27 +4,35 @@ import { Link } from "gatsby"
 
 
 const Header = ({ siteTitle }) => (
-  <Navbar
-    collapseOnSelect
-    expand="lg"
-    className="sunrise-nav"
-    style={{
-      marginBottom: `1.45rem`
-    }}
-  >
-    <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
-      Skip to main content
-    </a>
-    <Link className="nav-text text-body" to="/">{siteTitle}</Link>
-    <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-    <Navbar.Collapse id="responsive-navbar-nav">
-      <Nav className="ml-auto">
-        <Link className="nav-link" to="/">Home</Link>
-        <Link className="nav-link" to="/about">About</Link>
-        <Link className="nav-link" to="/terminology">Terminology</Link>
-      </Nav>
-    </Navbar.Collapse>
-  </Navbar>
+  <>
+    <Navbar
+      collapseOnSelect
+      expand="lg"
+      className="sunrise-nav"
+      style={{
+        marginBottom: `1.45rem`
+      }}
+    >
+      <a className="sr-only sr-only-focusable skip-link btn btn-light" href="#main">
+        Skip to main content
+      </a>
+      <Link className="nav-text text-body" to="/">{siteTitle}</Link>
+      <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+      <Navbar.Collapse id="responsive-navbar-nav">
+        <Nav className="ml-auto">
+          <Link className="nav-link" to="/">Home</Link>
+          {/* Commented out for now since these pages are empty
+            <Link className="nav-link" to="/about">About</Link>
+            <Link className="nav-link" to="/terminology">Terminology</Link>
+          */}
+        </Nav>
+      </Navbar.Collapse>
+    </Navbar>
+    <div class="alert alert-info ml-4 mr-4" role="alert">
+      <strong>Decarbonize My State is in an open beta! </strong>
+      Some content may still be missing.
+    </div>
+  </>
 )
 
 export default Header


### PR DESCRIPTION
## Overview

Removed header links to the empty terminology and about pages and added a basic beta notice.

| Desktop | Mobile (Home) | Mobile (State) 
| --- | --- | --- |
| ![Screenshot from 2022-05-24 21-50-10](https://user-images.githubusercontent.com/3187531/170169521-93684344-326d-4099-83da-47056b02c424.png) | ![Screenshot from 2022-05-24 21-50-19](https://user-images.githubusercontent.com/3187531/170169519-7c617a57-5315-45b5-b036-38802623173a.png) | ![Screenshot from 2022-05-24 21-51-53](https://user-images.githubusercontent.com/3187531/170169752-78ec1d76-f07d-41fa-8c36-04beb9608df9.png) |
### Demo

See description.

### Notes

None!

## Testing Instructions

* Just checked mobile and desktop to make sure the notice looked good and the links were gone