### PR TITLE
Add Data Table Modal as Alternative to Emissions Line Graphs for Accessibility

### DIFF
--- a/src/components/data-modal.js
+++ b/src/components/data-modal.js
@@ -28,12 +28,12 @@ export default function DataModal ({
 }) {
   return (
     <>
-      <Modal show={show} onHide={handleClose} scrollable={true}>
+      <Modal show={show} onHide={handleClose} scrollable centered>
         <Modal.Header closeButton>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         {/* Make modal body tabbable so keyboard users can scroll it */}
-        <Modal.Body className="data-modal-body" tabindex="0"
+        <Modal.Body className="data-modal-body" tabIndex="0"
           aria-label="Data Table Section">
           <Table striped bordered>
             <thead>

--- a/src/components/data-modal.js
+++ b/src/components/data-modal.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Button, Modal, ModalHeader, ModalTitle, ModalBody, ModalFooter } from "react-bootstrap"
+import { Button, Table, Modal } from "react-bootstrap"
 
 /**
  * A modal that we use to show a two-dimensional array of data. Used so that
@@ -7,21 +7,54 @@ import { Button, Modal, ModalHeader, ModalTitle, ModalBody, ModalFooter } from "
  *
  * Props:
  *
- * @param {Array<Array<number|string>>} chartData
+ * @param {Array<{ [key: string]: number|string}>} chartData
  *   The data to render
+ * @param {Array<{ key: string; title: string }>} headers
+ *   The headers to show for the data (e.g. ['Year', 'Emissions'])
  * @param {boolean} show
  *   Whether we shoud be showing the modal
+ * @param {string} title
+ *   The modal title/the title of the data set
  * @param {function} handleClose
  *   A callback function to close the modal
  */
-export default function DataModal({ chartData, show, handleClose }) {
+export default function DataModal ({
+  chartData,
+  headers,
+  show,
+  title = 'Emissions',
+  // Output function
+  handleClose,
+}) {
   return (
     <>
-      <Modal show={show} onHide={handleClose}>
+      <Modal show={show} onHide={handleClose} scrollable={true}>
         <Modal.Header closeButton>
-          <Modal.Title>Modal heading</Modal.Title>
+          <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <Modal.Body>Woohoo, you're reading this text in a modal!</Modal.Body>
+        {/* Make modal body tabbable so keyboard users can scroll it */}
+        <Modal.Body className="data-modal-body" tabindex="0"
+          aria-label="Data Table Section">
+          <Table striped bordered>
+            <thead>
+              <tr>
+                {headers.map((header, index) => (
+                  <td key={index}>{header.title}</td>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {chartData.map((row, index) => (
+                <tr key={index}>
+                  {headers.map((header, index) => (
+                    // Show — if no data
+                    <td key={index}>{row[header.key] || '—'}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary" onClick={handleClose}>
             Close
@@ -29,6 +62,6 @@ export default function DataModal({ chartData, show, handleClose }) {
         </Modal.Footer>
       </Modal>
     </>
-  );
+  )
 }
 

--- a/src/components/data-modal.js
+++ b/src/components/data-modal.js
@@ -1,0 +1,34 @@
+import React from "react"
+import { Button, Modal, ModalHeader, ModalTitle, ModalBody, ModalFooter } from "react-bootstrap"
+
+/**
+ * A modal that we use to show a two-dimensional array of data. Used so that
+ * screen reader users can access the data behind our graphs.
+ *
+ * Props:
+ *
+ * @param {Array<Array<number|string>>} chartData
+ *   The data to render
+ * @param {boolean} show
+ *   Whether we shoud be showing the modal
+ * @param {function} handleClose
+ *   A callback function to close the modal
+ */
+export default function DataModal({ chartData, show, handleClose }) {
+  return (
+    <>
+      <Modal show={show} onHide={handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Modal heading</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Woohoo, you're reading this text in a modal!</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+

--- a/src/components/simpleareachart.js
+++ b/src/components/simpleareachart.js
@@ -16,9 +16,9 @@ import DataModal from './data-modal'
 
 export default function SimpleAreaChart ({ emissionsData, title }) {
 
-  const YearDataKey = 'year';
-  const EmissionsDataKey = 'hist';
-  const ProjectionDataKey = 'projection';
+  const YearDataKey = 'year'
+  const EmissionsDataKey = 'hist'
+  const ProjectionDataKey = 'projection'
 
   const annualHistoricEmissions = emissionsData.map((item) => {
     var data = { [YearDataKey]: item.year, [EmissionsDataKey]: 0 }
@@ -59,7 +59,7 @@ export default function SimpleAreaChart ({ emissionsData, title }) {
     { title: 'Year', key: YearDataKey },
     { title: 'Gigatonnes CO2 Emitted', key: EmissionsDataKey },
     { title: 'Goal CO2 Emissions', key: ProjectionDataKey }
-  ];
+  ]
 
   const [showDataModal, setShowDataModal] = useState(false)
 

--- a/src/components/simpleareachart.js
+++ b/src/components/simpleareachart.js
@@ -1,4 +1,5 @@
-import React from "react"
+import React, { useState } from "react"
+import { Button } from "react-bootstrap"
 import {
   AreaChart,
   Area,
@@ -10,6 +11,8 @@ import {
   Label,
   ReferenceDot
 } from "recharts"
+
+import DataModal from './data-modal';
 
 export default function SimpleAreaChart ({ emissions_data }) {
 
@@ -38,48 +41,64 @@ export default function SimpleAreaChart ({ emissions_data }) {
 
   var data = annualhistoricalEmissions.concat(projection)
   const dataMidPoint = data.find(item => item.year === currYear).hist / 2
+
+  console.log('data', data);
+
+  const [showDataModal, setShowDataModal] = useState(false);
+
+  const handleCloseModal = () => setShowDataModal(false);
+  const handleShowModal = () => setShowDataModal(true);
   
   return (
-    <ResponsiveContainer className="simplearea-cont">
-      <AreaChart
-        width={800}
-        height={400}
-        data={data}
-        margin={{
-          top: 30,
-          right: 30,
-          left: 0,
-          bottom: 30
-        }}
-      >
-        {/* <Legend align="center" verticalAlign="top" iconType="square" iconSize="15" /> */}
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="year" >
-          <Label value="Year" offset={-15} position="insideBottom" />
-        </XAxis>
-        <YAxis />
-        <Tooltip />
-        <Area
-          type="monotone"
-          dataKey="hist"
-          stackId="1"
-          stroke="#b65c00"
-          fill="#e8ceb3"
-          name="Emissions"
-          isAnimationActive={false}
-        />
-        <Area
-          type="monotone"
-          dataKey="projected"
-          stackId="2"
-          stroke="#36a654"
-          fill="#c1e5cb"
-          name="Projection"
-          isAnimationActive={false}
-        />
-        <ReferenceDot y={dataMidPoint} x={currYear-4} stroke="none" fill="none" label={{ value: "Emissions", angle: 90, fill: "#b65c00" }} />
-        <ReferenceDot y={dataMidPoint} x={currYear+1} stroke="none" fill="none" label={{ value: "Projections", angle: 90, fill: "#36a654" }} />
-      </AreaChart>
-    </ResponsiveContainer>
+    <>
+      <ResponsiveContainer className="simplearea-cont">
+        <AreaChart
+          width={800}
+          height={400}
+          data={data}
+          margin={{
+            top: 30,
+            right: 30,
+            left: 0,
+            bottom: 30
+          }}
+        >
+          {/* <Legend align="center" verticalAlign="top" iconType="square" iconSize="15" /> */}
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="year" >
+            <Label value="Year" offset={-15} position="insideBottom" />
+          </XAxis>
+          <YAxis />
+          <Tooltip />
+          <Area
+            type="monotone"
+            dataKey="hist"
+            stackId="1"
+            stroke="#b65c00"
+            fill="#e8ceb3"
+            name="Emissions"
+            isAnimationActive={false}
+          />
+          <Area
+            type="monotone"
+            dataKey="projected"
+            stackId="2"
+            stroke="#36a654"
+            fill="#c1e5cb"
+            name="Projection"
+            isAnimationActive={false}
+          />
+          <ReferenceDot y={dataMidPoint} x={currYear-4} stroke="none" fill="none" label={{ value: "Emissions", angle: 90, fill: "#b65c00" }} />
+          <ReferenceDot y={dataMidPoint} x={currYear+1} stroke="none" fill="none" label={{ value: "Projections", angle: 90, fill: "#36a654" }} />
+        </AreaChart>
+      </ResponsiveContainer>
+
+      <Button variant="secondary" onClick={handleShowModal}>
+        View Data Table
+      </Button>
+
+      <DataModal show={showDataModal} chartData={data}
+        handleClose={handleCloseModal}></DataModal>
+    </>
   )
 }

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -305,7 +305,8 @@ export default function StateDetailsPage ({ location, data }) {
         <p className="h6">
           Million metric tons of carbon dioxide equivalent (MMTCO2e) emissions
         </p>
-        <SimpleAreaChart emissions_data={emissionsByYear} />
+        <SimpleAreaChart emissionsData={emissionsByYear}
+          title={'Emissions in ' + placeTitle}/>
 
         <p className="h1 font-weight-bold text-center mt-5">
           We can do it. Here's how.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -73,7 +73,8 @@ const IndexPage = ({data}) => {
       <p className="h6">
         Million metric tons of CO<sub>2</sub> equivalent (MMTCO2e) emissions
       </p>
-      <SimpleAreaChart emissions_data={emissionsOverTime}/>
+      <SimpleAreaChart emissionsData={emissionsOverTime}
+        title="Total US Emissions"/>
 
       <p className='h2 text-center mt-7 mb-5'>
         To do that (and solve the climate crisis) there's one main thing

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -339,3 +339,5 @@ footer a {
     font-weight: bolder;
     line-height: 90px;
 }
+
+.data-modal-body { max-height: 40vh; }


### PR DESCRIPTION
## Overview

Adds a "View Data Table" button below all single area charts (including on the homepage and state details page) which opens a modal with the related table in data form. This is so screen reader users can still get a view of the data without the visual representation of the graph.

https://user-images.githubusercontent.com/3187531/176341135-3a0a6f23-158a-43d0-9cb8-26e877c90dd3.mp4

Closes #105 

### Demo

See description.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- On mobile and desktop, confirm the modal is usable on the homepage and on a state details page