### PR TITLE
create take-action page with call to action copy and google form

### DIFF
--- a/src/pages/take-action.js
+++ b/src/pages/take-action.js
@@ -9,8 +9,8 @@ const TakeActionPage = ({data, location}) => {
     <Layout>
       <SEO title="Take Action! :: Decarbonize My State" />
       <div className="container">
-       <h1>Ready to do your part?</h1>
-       <p>The best way to decarbonize your state is to electrify it. There are two big ways you can do your part.</p>
+        <h1>Ready to do your part?</h1>
+        <p>The best way to decarbonize your state is to electrify it. There are two big ways you can do your part.</p>
         <h2>Get Personal: Electrify your machines!</h2>
         <p>
           For most Americans, more than half your carbon footprint comes from how you heat and power your home, and from the car you drive. 
@@ -40,17 +40,17 @@ const TakeActionPage = ({data, location}) => {
             <a href="https://www.climateslate.com/candidates?filter-by-Priority=Top%20Priority">Donate Now.</a> 
           </li>
           <li>
-          <div class="font-weight-bold">
+            <div class="font-weight-bold">
           Pressure Electeds to Pass Climate Policy:
-          </div>
+            </div>
            It’s not enough to elect better candidates - we also have to pressure existing electeds to pass key climate policy now. Campaigns to do this already exist in your state – the highest impact thing you can do is join them. Sign up below and we will share what we know about climate campaigns in your state.
           </li>
         </ul>
         <h2>Learn about climate campaigns in your state!</h2>
-        <div class="form-container">
-          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdiwiT6OZO0jsnLu22r6ClBZLh8fvfGIiYu_5coOvjYXqogtw/viewform?embedded=true" width="640" height="720" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+        <div class="form-container embed-responsive embed-responsive-16by9">
+          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdiwiT6OZO0jsnLu22r6ClBZLh8fvfGIiYu_5coOvjYXqogtw/viewform?embedded=true" class="embed-responsive-item " width="640" height="1720" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
         </div>
-        </div>
+      </div>
     </Layout>
   )
 }

--- a/src/pages/take-action.js
+++ b/src/pages/take-action.js
@@ -1,0 +1,58 @@
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const TakeActionPage = ({data, location}) => {
+
+  return (
+    <Layout>
+      <SEO title="Take Action! :: Decarbonize My State" />
+      <div className="container">
+       <h1>Ready to do your part?</h1>
+       <p>The best way to decarbonize your state is to electrify it. There are two big ways you can do your part.</p>
+        <h2>Get Personal: Electrify your machines!</h2>
+        <p>
+          For most Americans, more than half your carbon footprint comes from how you heat and power your home, and from the car you drive. 
+          More than cutting out meat or single use plastics, the most impactful thing you can do – by far – is to eliminate your personal burning of fossil fuels:
+        </p>
+        <ol>
+          <li>Produce you own power with solar panels</li>
+          <li>Replace your heating system with a heat pump, your gas stove with an induction stove.</li>
+          <li>Replace your gas car with an electric one.</li>
+        </ol>
+        <p>
+          40% of US climate pollution comes from decisions made around the kitchen table. We can’t solve climate change if you don’t electrify your home – and nobody can do it but you.
+        </p>
+        <h2>
+          Get Political: Electrify the rest!
+        </h2>
+        <p>
+        Discouraged by the inaction at the federal level? We can still win: 50-75% of the policies we need to get to zero are actually state and local. And we’re starting to win them!
+        </p>
+        <p>
+          By all means, electrify your machines. To electrify the rest, support the candidates and issue campaigns already fighting to decarbonize your state. 
+        </p>
+        <ul>
+          <li>
+            <div class="font-weight-bold">Elect Climate Candidates:</div>
+            You can take meaningful action right now by donating to Climate Cabinet, a political action group that helps climate champions run for local office and pass critical legislation, 
+            <a href="https://www.climateslate.com/candidates?filter-by-Priority=Top%20Priority">Donate Now.</a> 
+          </li>
+          <li>
+          <div class="font-weight-bold">
+          Pressure Electeds to Pass Climate Policy:
+          </div>
+           It’s not enough to elect better candidates - we also have to pressure existing electeds to pass key climate policy now. Campaigns to do this already exist in your state – the highest impact thing you can do is join them. Sign up below and we will share what we know about climate campaigns in your state.
+          </li>
+        </ul>
+        <h2>Learn about climate campaigns in your state!</h2>
+        <div class="form-container">
+          <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdiwiT6OZO0jsnLu22r6ClBZLh8fvfGIiYu_5coOvjYXqogtw/viewform?embedded=true" width="640" height="720" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+        </div>
+        </div>
+    </Layout>
+  )
+}
+
+export default TakeActionPage

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -342,4 +342,5 @@ footer a {
 
 .form-container { 
     display: table;
+    height: 810px;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -339,3 +339,7 @@ footer a {
     font-weight: bolder;
     line-height: 90px;
 }
+
+.form-container { 
+    display: table;
+}


### PR DESCRIPTION
## Overview

I have created a new page: /take-action within the application, and added the call-to-action copy from the google doc, as well as the google form within an iframe. I carried over the basic formatting/markup from the doc.

Closes #65 

### Demo

![image](https://user-images.githubusercontent.com/27985352/176792686-fa224514-906c-428b-828f-59e17a5e16fc.png)
### Notes
Open to feedback on the styling.