### PR TITLE
add take action links

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -22,18 +22,10 @@ const Header = ({ siteTitle }) => (
         <Nav className="ml-auto">
           <Link className="nav-link" to="/">Home</Link>
           <Link className="nav-link" to="/about">About</Link>
-          {/* Commented out for now since these pages are empty
-            <Link className="nav-link" to="/terminology">Terminology</Link>
-          */}
+          <Link className="nav-link" to="/take-action">Take Action</Link>
         </Nav>
       </Navbar.Collapse>
     </Navbar>
-    <div className="container">
-      <div className="alert alert-info ml-4 mr-4" role="alert">
-        <strong>Decarb My State is in an open beta! </strong>
-        Some content or links may be missing.
-      </div>
-    </div>
   </>
 )
 

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import Scrollspy from "react-scrollspy"
 import "react-bootstrap-table-next/dist/react-bootstrap-table2.min.css"
 import SingleBarChart from "../components/singlebar"
@@ -750,17 +750,17 @@ export default function StateDetailsPage ({ location, data }) {
         </Scrollspy>
       </div>
 
-      <hr className="mt-7" />
+      <hr className="mt-5" />
 
       <section className="text-center mb-8">
-        <div className="h1 mt-7">✅</div>
+        <div className="h1 mt-5">✅</div>
         <br className="d-none d-lg-block" />
         <div className="h1 font-weight-bold">Ready to do your part?</div>
 
         <p className="h4 mt-4">
           Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
           <br className="d-none d-lg-block" />
-          <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
+          <Link className='btn btn-lg btn-success mt-5' to='/take-action'>Take Action</Link>
         </p>
       </section>
     </Layout>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -449,24 +449,6 @@ export default function StateDetailsPage ({ location, data }) {
               />
             </div>
 
-            <div className="action-panel">
-              <h3 className="h4 font-weight-bold">What should I do?</h3>
-
-              {/* TODO: Make these link somewhere */}
-              <ul className="mt-3 pl-4 mb-0">
-                <li>
-                  <a href="http://example.com">
-                    First, electrify your building(s)
-                  </a>
-                </li>
-                <li>
-                  <a href="http://example.com">
-                    Then push your local politicians to electrify the rest
-                  </a>
-                </li>
-              </ul>
-            </div>
-
             <hr className="mt-7" />
           </div>
 
@@ -532,22 +514,6 @@ export default function StateDetailsPage ({ location, data }) {
                 emissionsData={latestEmissions}
                 greenKeys={["buildings", "transportation"]}
               />
-            </div>
-
-            <div className="action-panel">
-              <h3 className="h4 font-weight-bold">What should I do?</h3>
-
-              {/* TODO: Make these link somewhere */}
-              <ul className="mt-3 pl-4 mb-0">
-                <li>
-                  <a href="http://example.com">If you have a car, buy an EV</a>
-                </li>
-                <li>
-                  <a href="http://example.com">
-                    Then push your local politicians to electrify the rest
-                  </a>
-                </li>
-              </ul>
             </div>
 
             <hr className="mt-7" />
@@ -714,24 +680,6 @@ export default function StateDetailsPage ({ location, data }) {
                 />
               </div>
 
-              <div className="action-panel">
-                <h3 className="h4 font-weight-bold">What should I do?</h3>
-
-                {/* TODO: Make these link somewhere */}
-                <ul className="mt-3 pl-4 mb-0">
-                  <li>
-                    <a href="http://example.com">
-                      Install solar panels and a battery in your building
-                    </a>
-                  </li>
-                  <li>
-                    <a href="http://example.com">
-                      Support the construction of grid-scale wind and solar
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
               <hr className="mt-7" />
             </div>
           )}
@@ -805,12 +753,14 @@ export default function StateDetailsPage ({ location, data }) {
       <hr className="mt-7" />
 
       <section className="text-center mb-8">
-        <div className="h1 mt-7 font-weight-bold">And that's it! 🎉</div>
+        <div className="h1 mt-7">✅</div>
+        <br className="d-none d-lg-block" />
+        <div className="h1 font-weight-bold">Ready to do your part?</div>
 
         <p className="h4 mt-4">
-          We hope this gives you some ideas for what you{" "}
+          Learn how to <strong>electrify your own machines</strong> and how to <strong>pass local policy</strong> to electrify the rest
           <br className="d-none d-lg-block" />
-          can do to get your state to zero emissions!
+          <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
         </p>
       </section>
     </Layout>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -758,7 +758,7 @@ export default function StateDetailsPage ({ location, data }) {
         <div className="h1 font-weight-bold">Ready to do your part?</div>
 
         <p className="h4 mt-4">
-          Learn how to <strong>electrify your own machines</strong> and how to <strong>pass local policy</strong> to electrify the rest
+          Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
           <br className="d-none d-lg-block" />
           <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
         </p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -47,7 +47,7 @@ const IndexPage = ({data}) => {
           to decarb your state?
         </h1>
         <p className="h3 text-center mt-2">
-          The answer is simpler than you think.
+          The answer to climate change is simpler than you think
         </p>
       </div>
 
@@ -67,6 +67,19 @@ const IndexPage = ({data}) => {
 
         <StatesList stateSlugs={stateSlugs}/>
       </div>
+
+      <hr className="mt-7" />
+
+      <section className="text-center mb-8">
+        <br className="d-none d-lg-block" />
+        <div className="h1 font-weight-bold">Ready to do your part now?</div>
+
+        <p className="h4 mt-4">
+          Learn how to <strong>electrify your own machines</strong> and how to <strong>pass local policy</strong> to electrify the rest
+          <br className="d-none d-lg-block" />
+          <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
+        </p>
+      </section>
     </Layout>
   )
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { graphql } from "gatsby"
+import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import ChoroplethMap from "../components/choroplethmap"
@@ -70,14 +70,14 @@ const IndexPage = ({data}) => {
 
       <hr className="mt-7" />
 
-      <section className="text-center mb-8">
+      <section className="text-center mb-8 mt-7">
         <br className="d-none d-lg-block" />
-        <div className="h1 font-weight-bold">Ready to do your part now?</div>
+        <h2 className="h1 font-weight-bold">Ready to do your part now?</h2>
 
         <p className="h4 mt-4">
           Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
           <br className="d-none d-lg-block" />
-          <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
+          <Link className='btn btn-lg btn-success mt-5' to='/take-action'>Take Action</Link>
         </p>
       </section>
     </Layout>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,7 +75,7 @@ const IndexPage = ({data}) => {
         <div className="h1 font-weight-bold">Ready to do your part now?</div>
 
         <p className="h4 mt-4">
-          Learn how to <strong>electrify your own machines</strong> and how to <strong>pass local policy</strong> to electrify the rest
+          Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
           <br className="d-none d-lg-block" />
           <a class='btn btn-lg btn-outline-secondary my-4' href='/take-action'>Take Action</a>
         </p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -198,16 +198,6 @@ footer a {
     box-shadow: 0 1px 2px #bdbdbd;
 }
 
-.action-panel {
-    padding: 2rem;
-    margin:  5rem 0;
-    background-color: #f3f3f3;
-}
-
-.action-panel a {
-    color: #004da1;
-}
-
 .state-links {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Overview

Adds Take Action link to:
- header nav
- index page below the map
- state detail pages at the bottom

Removes beta banner since all links are now populated.

Related to #117 

### Demo

<img width="1507" alt="Screen Shot 2022-07-06 at 9 21 33 PM" src="https://user-images.githubusercontent.com/919583/177676304-aca326a6-5d23-45a1-aca6-708bb8446dc8.png">

## Testing Instructions

* review the home page and state detail pages and confirm the take action section looks good