### PR TITLE
better markup for mobile styling of take action link

### DIFF
--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -759,9 +759,8 @@ export default function StateDetailsPage ({ location, data }) {
 
         <p className="h4 mt-4">
           Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
-          <br className="d-none d-lg-block" />
-          <Link className='btn btn-lg btn-success mt-5' to='/take-action'>Take Action</Link>
         </p>
+        <Link className='btn btn-lg btn-success mt-4' to='/take-action'>Take Action</Link>
       </section>
     </Layout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,9 +76,8 @@ const IndexPage = ({data}) => {
 
         <p className="h4 mt-4">
           Learn how to <strong>electrify your own machines</strong> and <strong>pass local policy</strong> to electrify the rest
-          <br className="d-none d-lg-block" />
-          <Link className='btn btn-lg btn-success mt-5' to='/take-action'>Take Action</Link>
         </p>
+        <Link className='btn btn-lg btn-success mt-4' to='/take-action'>Take Action</Link>
       </section>
     </Layout>
   )


### PR DESCRIPTION
## Overview

Fixes mobile alignment of the Take Action link.

Before:

![Image from iOS](https://user-images.githubusercontent.com/919583/177899164-0b20cf66-30e9-45fa-a34a-9e0f8f247e06.png)

After: 

![Screen Shot 2022-07-07 at 8 39 40 PM](https://user-images.githubusercontent.com/919583/177899389-83ec51c6-4598-4cea-a651-1a70f594af2e.png)



## Testing Instructions

* view the site on mobile and confirm the take action button is positioned correctly