### PR TITLE
using proper Gtag stream ID

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,7 @@ module.exports = {
       options: {
         // You can add multiple tracking ids and a pageview event will be fired for all of them.
         trackingIds: [
-          "G-HMC3YZ0H3D", // Google Analytics / GA
+          "G-PSQR8C650G", // Google Analytics / GA
         ],
         // This object gets passed directly to the gtag config command
         // This config will be shared across all trackingIds


### PR DESCRIPTION
## Overview

I don't know why, but we had the wrong Google Tag Stream ID in our config. This PR fixes it.

## Testing Instructions

* must be tested on production