### PR TITLE
gtag configuration (again)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -49,7 +49,7 @@ module.exports = {
           head: false,
           // Setting this parameter is also optional
           respectDNT: true,
-          origin: "https://decarbonizemystate.com",
+          origin: "https://decarbmystate.com",
         },
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,20 +37,6 @@ module.exports = {
         trackingIds: [
           "G-PSQR8C650G", // Google Analytics / GA
         ],
-        // This object gets passed directly to the gtag config command
-        // This config will be shared across all trackingIds
-        gtagConfig: {
-          anonymize_ip: true,
-          cookie_expires: 0,
-        },
-        // This object is used for configuration specific to this plugin
-        pluginConfig: {
-          // Puts tracking script in the head instead of the body
-          head: false,
-          // Setting this parameter is also optional
-          respectDNT: true,
-          origin: "https://decarbmystate.com",
-        },
       },
     },
     {


### PR DESCRIPTION
## Overview

Google Analytics is still not working. This PR removes extra configuration from `gatsby-plugin-google-gtag`. I believe the `origin` was incorrectly configured.

I was able to successfully test this in the deploy preview using the Google Analytics Debugger: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en

Also, finally seeing data in Analytics:

![Screen Shot 2022-07-12 at 2 51 44 PM](https://user-images.githubusercontent.com/919583/178582509-07d0768a-fea6-4f16-9d68-71e74d7abbc3.png)


## Testing Instructions

* download and turn on the Google Analytics Debugger in Chrome: https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en
* open the deploy preview and confirm the console output shows the debugger output. It should look like:

<img width="964" alt="Screen Shot 2022-07-12 at 2 51 16 PM" src="https://user-images.githubusercontent.com/919583/178582297-024f9762-67ee-4c3a-915d-1e07b2be8933.png">

