### PR TITLE
Fix Homepage Typo

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -38,7 +38,7 @@ const IndexPage = ({data}) => {
       />
       <div className="main-header">
         <h1 id="main" className="display-4 text-center font-weight-bold">
-          What does take...<br/>
+          What does it take...<br/>
           to decarbonize your state?
         </h1>
         <p className="h3 text-center mt-2">


### PR DESCRIPTION
## Overview

Adds the word "It" to the homepage.

Closes #XXX

### Demo

Just try it 😆 

### Notes

None.

## Testing Instructions

* Confirm homepage sentence looks good on mobile and desktop