### PR TITLE
Annual Counts Fix for Vehicles & Buildings

### DIFF
--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -126,14 +126,19 @@ export default function StateDetailsPage ({ location, data }) {
     Cars_All: carsAll,
     EV_Registration: evRegistration,
   } = data.allVehiclesJson.edges[0].node
+  
   const pctEv = Math.round((evRegistration / carsAll) * 100 * 10) / 10
   const pctNonEv = Math.round((100 - pctEv) * 10) / 10
+
+  // calculate cars remaining to electrify
+  const carsToElectrify = carsAll * (pctNonEv/100)
+  
   // string formatting
   const carsCountStr =
-    carsAll !== undefined ? numberToHumanString(carsAll) : "?"
+    carsToElectrify !== undefined ? numberToHumanString(carsToElectrify) : "?"
   const carsPerYear =
-    carsAll !== undefined
-      ? numberToHumanString(Math.ceil((carsAll * cutPerYearPrcnt) / 100))
+    carsToElectrify !== undefined
+      ? numberToHumanString(Math.ceil((carsToElectrify * cutPerYearPrcnt) / 100))
       : "?"
   const evCountStr =
     evRegistration !== undefined ? numberToHumanString(evRegistration) : "?"
@@ -145,12 +150,16 @@ export default function StateDetailsPage ({ location, data }) {
     weightedEleBuildingsPct,
   } = data.allBuildingsJson.edges[0].node
 
+  // calculate buildings remaining to electrify
+  const buildingsToElectrify = (weightedEleBuildingsPct !== 0 ||
+    weightedFossilBuildingsPct !== 0) ? buildings * (weightedFossilBuildingsPct/100) : buildings
+
   // string formatting
   const buildingsCountStr =
-    buildings !== undefined ? numberToHumanString(buildings) : "?"
+  buildingsToElectrify !== undefined ? numberToHumanString(buildingsToElectrify) : "?"
   const buildingsPerYear =
-    buildings !== undefined
-      ? numberToHumanString(Math.ceil((buildings * cutPerYearPrcnt) / 100))
+  buildingsToElectrify !== undefined
+      ? numberToHumanString(Math.ceil((buildingsToElectrify * cutPerYearPrcnt) / 100))
       : "?"
 
   // #### SOLAR PANELS & WIND TURBINES ####
@@ -418,11 +427,6 @@ export default function StateDetailsPage ({ location, data }) {
               />
             </p>
 
-            <p className="h3 mt-5">
-              And we need to do this for all {buildingsCountStr} buildings in{" "}
-              {placeTitle}. That's around {buildingsPerYear} per year.
-            </p>
-
             {(weightedEleBuildingsPct !== 0 ||
               weightedFossilBuildingsPct !== 0) && (
               <p className="h3 mt-5">
@@ -435,6 +439,11 @@ export default function StateDetailsPage ({ location, data }) {
               electrifiedPct={weightedEleBuildingsPct}
               fossilPct={weightedFossilBuildingsPct}
             />
+
+            <p className="h3 mt-5">
+              We need to electrify the remaining {buildingsCountStr} buildings in{" "}
+              {placeTitle}. That's around {buildingsPerYear} per year.
+            </p>
           </div>
 
           <div id="bld-end" className="scrollable-sect mt-8 mb-7">
@@ -488,10 +497,6 @@ export default function StateDetailsPage ({ location, data }) {
                 </p>
 
                 <p className="mt-5">
-                  And we need to do this for all {carsCountStr} cars in{" "}
-                  {placeTitle}. That's around {carsPerYear} a year.
-                </p>
-                <p className="mt-5">
                   {evCountStr} vehicles in {placeTitle} are already EVs ({pctEv}
                   % of the total).
                 </p>
@@ -500,6 +505,11 @@ export default function StateDetailsPage ({ location, data }) {
                   electrifiedPct={pctEv}
                   fossilPct={pctNonEv}
                 />
+
+                <p className="mt-5">
+                  We need to electrify the remaining {carsCountStr} cars in{" "}
+                  {placeTitle}. That's around {carsPerYear} a year.
+                </p>
               </div>
             </div>
           </div>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -434,7 +434,7 @@ export default function StateDetailsPage ({ location, data }) {
             {(weightedEleBuildingsPct !== 0 ||
               weightedFossilBuildingsPct !== 0) && (
               <p className="h3 mt-5">
-                There are {buildingsCountStr} buildings in {placeTitle} and {Math.round(weightedEleBuildingsPct)}% of building systems'
+                There are {buildingsCountStr} buildings in {placeTitle} and {Math.round(weightedEleBuildingsPct)}% of building systems
                 are already electrified. 
               </p>
             )}

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -135,6 +135,8 @@ export default function StateDetailsPage ({ location, data }) {
   
   // string formatting
   const carsCountStr =
+    carsToElectrify !== undefined ? numberToHumanString(carsAll) : "?"
+  const carsLeftStr =
     carsToElectrify !== undefined ? numberToHumanString(carsToElectrify) : "?"
   const carsPerYear =
     carsToElectrify !== undefined
@@ -156,6 +158,8 @@ export default function StateDetailsPage ({ location, data }) {
 
   // string formatting
   const buildingsCountStr =
+  buildings !== undefined ? numberToHumanString(buildings) : "?"
+  const buildingsLeftStr =
   buildingsToElectrify !== undefined ? numberToHumanString(buildingsToElectrify) : "?"
   const buildingsPerYear =
   buildingsToElectrify !== undefined
@@ -430,20 +434,21 @@ export default function StateDetailsPage ({ location, data }) {
             {(weightedEleBuildingsPct !== 0 ||
               weightedFossilBuildingsPct !== 0) && (
               <p className="h3 mt-5">
-                {Math.round(weightedEleBuildingsPct)}% of building systems'
-                energy use in {placeTitle} are already electrified.
+                There are {buildingsCountStr} buildings in {placeTitle} and {Math.round(weightedEleBuildingsPct)}% of building systems'
+                are already electrified. 
               </p>
             )}
+
+            <p className="h3 mt-5">
+              We need to electrify the remaining {buildingsLeftStr} buildings in{" "}
+              {placeTitle}. That's around {buildingsPerYear} per year.
+            </p>
             <AlreadyElectrifiedChart
               label={"Building Systems"}
               electrifiedPct={weightedEleBuildingsPct}
               fossilPct={weightedFossilBuildingsPct}
             />
 
-            <p className="h3 mt-5">
-              We need to electrify the remaining {buildingsCountStr} buildings in{" "}
-              {placeTitle}. That's around {buildingsPerYear} per year.
-            </p>
           </div>
 
           <div id="bld-end" className="scrollable-sect mt-8 mb-7">
@@ -497,19 +502,17 @@ export default function StateDetailsPage ({ location, data }) {
                 </p>
 
                 <p className="mt-5">
-                  {evCountStr} vehicles in {placeTitle} are already EVs ({pctEv}
-                  % of the total).
+                  There are {carsCountStr} vehicles in {placeTitle} and {evCountStr}{" "} 
+                  are already electric ({pctEv}% of the total). 
+                </p>
+                <p className="mt-5">
+                  We need to electrify the remaining {carsLeftStr} vehicles. That's around {carsPerYear} a year.
                 </p>
                 <AlreadyElectrifiedChart
                   label={"Vehicles"}
                   electrifiedPct={pctEv}
                   fossilPct={pctNonEv}
                 />
-
-                <p className="mt-5">
-                  We need to electrify the remaining {carsCountStr} cars in{" "}
-                  {placeTitle}. That's around {carsPerYear} a year.
-                </p>
               </div>
             </div>
           </div>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -131,7 +131,7 @@ export default function StateDetailsPage ({ location, data }) {
   const pctNonEv = Math.round((100 - pctEv) * 10) / 10
 
   // calculate cars remaining to electrify
-  const carsToElectrify = carsAll * (pctNonEv/100)
+  const carsToElectrify = carsAll - evRegistration
   
   // string formatting
   const carsCountStr =

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -159,8 +159,8 @@ export default function StateDetailsPage ({ location, data }) {
   buildingsToElectrify !== undefined ? numberToHumanString(buildingsToElectrify) : "?"
   const buildingsPerYear =
   buildingsToElectrify !== undefined
-      ? numberToHumanString(Math.ceil((buildingsToElectrify * cutPerYearPrcnt) / 100))
-      : "?"
+    ? numberToHumanString(Math.ceil((buildingsToElectrify * cutPerYearPrcnt) / 100))
+    : "?"
 
   // #### SOLAR PANELS & WIND TURBINES ####
   const targetBuilds = data.allTargetGenerationJson.edges[0].node

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -172,9 +172,8 @@ const AboutPage = ({data}) => {
 
           <h2 className="pt-3">Code</h2>
           <p>
-            All the code for this site is open source and available on
-            <a href="https://github.com/chihacknight/decarbonize-my-state/">GitHub</a>
-            under the MIT license.
+            All the code for this site is open source and available on{" "}
+            <a href="https://github.com/chihacknight/decarbonize-my-state/">GitHub</a> under the MIT license.
           </p>
 
           <p>Technologies used:</p>
@@ -188,13 +187,13 @@ const AboutPage = ({data}) => {
           
           <h2 className="pt-3">Contact us</h2>
           <p>
-            Found a bug?
+            Found a bug?{" "}
             <a href="https://github.com/chihacknight/decarbonize-my-state/issues">
               Report it on our issue tracker!
             </a>
           </p>
           <p>
-            Have a suggestion or question? Contact us at
+            Have a suggestion or question? Contact us at{" "}
             <a href="mailto:info@decarbmystate.com">info@decarbmystate.com</a>
           </p>
         </div>

--- a/src/pages/take-action.js
+++ b/src/pages/take-action.js
@@ -71,7 +71,7 @@ const TakeActionPage = () => {
             </p>
             <p>
               <a className="btn btn-success"
-                href="https://www.climateslate.com/candidates?filter-by-Priority=Top%20Priority">
+                href="https://secure.actblue.com/donate/climateslate?refcode=decarbmystate">
                 Donate to the Climate Slate by Climate Cabinet
               </a>
             </p>


### PR DESCRIPTION
## Overview

This pull request updates the calculations we make counting cars and buildings to be electrified to account for the already electrified percentages. Slightly changes the order of the text and bar chart so we establish the percentage before we account for it in the annual count.

Additional changes:
* small spacing fixes for links on the about page
* updates link to Climate Cabinet to a custom ActBlue URL

Closes #127

### Demo

**Buildings** 

before
<img width="660" alt="Screen Shot 2022-07-20 at 10 00 53 PM" src="https://user-images.githubusercontent.com/919583/180120725-8e9efbb5-1379-40d4-867b-63ee7773c1f9.png">

after
<img width="656" alt="Screen Shot 2022-07-20 at 10 00 08 PM" src="https://user-images.githubusercontent.com/919583/180120744-21e36843-5433-4f3e-9633-73b307332a27.png">


**Cars**

before
<img width="681" alt="Screen Shot 2022-07-20 at 10 01 38 PM" src="https://user-images.githubusercontent.com/919583/180120789-f623e7cf-928f-4321-9a2b-24747fb682f1.png">

after
<img width="665" alt="Screen Shot 2022-07-20 at 10 01 46 PM" src="https://user-images.githubusercontent.com/919583/180120807-cd5c917c-131f-4b30-9b25-544ef9e8401d.png">


## Testing Instructions

* view the state detail pages and confirm the building and vehicle counts look accurate
* check states like Alaska and Hawaii that have no building electrification percentage info
* check the about page and confirm we don't have any links without spaces around them