### PR TITLE
Fix Deprecated About Link and Add Car Free Note

### DIFF
--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -493,8 +493,8 @@ export default function StateDetailsPage ({ location, data }) {
                   to be an electric vehicle (EV).
                 </p>
                 <p className="mt-5">
-                  Or go car free with public transit, an ebike, or another zero
-                  emission mobility option.
+                  Or try going car free when public transit, e-bikes, or other
+                  zero mobility options are available.
                 </p>
 
                 <p className="mt-5 mb-0">

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -492,6 +492,10 @@ export default function StateDetailsPage ({ location, data }) {
                   To cut this pollution, if you have a car, your next one needs
                   to be an electric vehicle (EV).
                 </p>
+                <p className="mt-5">
+                  Or go car free with public transit, an ebike or other zero
+                  emission mobility options.
+                </p>
 
                 <p className="mt-5 mb-0">
                   <img

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -493,8 +493,8 @@ export default function StateDetailsPage ({ location, data }) {
                   to be an electric vehicle (EV).
                 </p>
                 <p className="mt-5">
-                  Or go car free with public transit, an ebike or other zero
-                  emission mobility options.
+                  Or go car free with public transit, an ebike, or another zero
+                  emission mobility option.
                 </p>
 
                 <p className="mt-5 mb-0">

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -493,8 +493,8 @@ export default function StateDetailsPage ({ location, data }) {
                   to be an electric vehicle (EV).
                 </p>
                 <p className="mt-5">
-                  Or try going car free when public transit, e-bikes, or other
-                  zero mobility options are available.
+                  Or try going car-free with public transit, bikes/e-bikes, or
+                  walking if it works for you.
                 </p>
 
                 <p className="mt-5 mb-0">

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -133,7 +133,7 @@ const AboutPage = ({data}) => {
 
           <p>
             <a className="font-weight-bold"
-              href="https://www.nrel.gov/docs/fy22osti/81186.pdf">
+              href="https://www.nrel.gov/docs/fy22osti/83063.pdf">
               U.S. Building Stock Characterization Study
             </a>
             <br />The National Renewable Energy Laboratory (NREL)


### PR DESCRIPTION
## Overview

Fixed the NREL link pointing to a PDF that pointed to an updated PDF (now saving a user the redirect) and added a new short sentence about ditching cars:

![Screenshot from 2022-07-25 22-22-03](https://user-images.githubusercontent.com/3187531/180916163-642d049b-b7e7-454c-8a38-0814ab581be1.png)

I thought this was important to add because from an overall materials perspective bikes and public transit are much much more efficient, but they aren't an option for everyone, so I think making it a secondary mention is a good fit for this site. Basically I want it to read as "Have a car? You should switch to an EV, but consider other options too".

### Demo

See description.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Tested changed NREL Link and confirmed new text looks good on desktop and mobile.