### PR TITLE
Fix State Details Page Rework Bugs

### DIFF
--- a/src/components/displayplants.js
+++ b/src/components/displayplants.js
@@ -44,7 +44,7 @@ const DisplayPlants = ({ plants, plantImage }) => {
               title={title}
               alt={title}
             />
-            <p className="font-weight-bold text-center">
+            <p className="font-weight-bold text-center h6">
               {plant.plant_name} <br/>
               <span className="small">
                 {plant.county} County<br/>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -418,7 +418,7 @@ export default function StateDetailsPage ({ location, data }) {
 
             <p className="mt-6">We'll replace...</p>
             <div className="mt-4 mb-4">
-              <ul>
+              <ul className="h4">
                 <li>
                   Boilers and furnaces with{" "}
                   <a
@@ -453,14 +453,14 @@ export default function StateDetailsPage ({ location, data }) {
               <strong>{buildingsCountStr} buildings</strong>.
             </p>
 
-            <div className="d-flex align-items-end justify-content-around mt-6">
+            <div className="d-flex align-items-end justify-content-around mt-5">
               <div className="col-6 building-sheet -house -clean"></div>
               <div className="col-6 building-sheet -apartments -clean"></div>
             </div>
 
             {(weightedEleBuildingsPct !== 0 ||
               weightedFossilBuildingsPct !== 0) && (
-              <p className="mt-8">
+              <p className="mt-7">
                 In fact, {Math.round(weightedEleBuildingsPct)}% of buildings in{" "}
                 {placeTitle} are already fossil fuel free!
               </p>
@@ -478,7 +478,7 @@ export default function StateDetailsPage ({ location, data }) {
             />
           </div>
 
-          <div id="bld-end" className="scrollable-sect mt-8 mb-4">
+          <div id="bld-end" className="scrollable-sect change-text mt-8 mb-4">
             <p className="h1 font-weight-bold text-center mt-6 mb-6">
               Electrifying all buildings cuts {buildingsPrcnt}% of the
               pollution.
@@ -536,7 +536,7 @@ export default function StateDetailsPage ({ location, data }) {
               share, or other alternatives!
             </p>
 
-            <p className="mt-8">
+            <p className="mt-6">
               Then, we'll electrify all{" "}
               <strong>{carsCountStr} cars and trucks</strong> in {placeTitle}!
             </p>
@@ -562,7 +562,7 @@ export default function StateDetailsPage ({ location, data }) {
             />
           </div>
 
-          <div id="transport-end" className="scrollable-sect mt-8 mb-4">
+          <div id="transport-end" className="scrollable-sect change-text mt-8 mb-4">
             <p className="h1 font-weight-bold text-center mt-6 mb-6">
               Electrifying all transportation cuts {transportPrcnt}% of the
               pollution.
@@ -619,10 +619,10 @@ export default function StateDetailsPage ({ location, data }) {
               </p>
 
               <div className="d-flex justify-content-center">
-                <div className="building-sheet -house -clean col-8"></div>
+                <div className="building-sheet -house -clean col-10"></div>
               </div>
 
-              <p className="mt-8">
+              <p className="mt-6">
                 Then, we'll replace{" "}
                 <strong>all fossil fuel power plants</strong> with solar and
                 wind farms.
@@ -740,7 +740,7 @@ export default function StateDetailsPage ({ location, data }) {
           )}
           {/* Show standard outro section if power emissions are non-zero */}
           {powerPrcnt > 0 && (
-            <div id="power-end" className="scrollable-sect mt-8 mb-4">
+            <div id="power-end" className="scrollable-sect change-text mt-8 mb-4">
               <p className="h1 font-weight-bold text-center mt-6 mb-6">
                 Decarbonizing all dirty power cuts {powerPrcnt}% of the
                 pollution.
@@ -813,7 +813,7 @@ export default function StateDetailsPage ({ location, data }) {
                   to solve these problems, but there are lots of great ideas:
                 </p>
 
-                <ul>
+                <ul className="h5 mt-4">
                   {/* All emojis in this context are decorative, so they are
                       marked with aria-hidden */}
                   <li>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -709,8 +709,8 @@ export default function StateDetailsPage ({ location, data }) {
               </p>
 
               <p className="mt-6">
-                In all, we'll need to build <strong>{windTurbinesCountStr} MWs</strong> of wind
-                and <strong>{solarPanelsCountStr} MWs</strong> of solar.
+                In all, we'll need to build <strong>{windTurbinesCountStr} Megawatts</strong> of wind
+                and <strong>{solarPanelsCountStr} Megawatts</strong> of solar.
               </p>
 
               <p className="mt-5">
@@ -789,7 +789,7 @@ export default function StateDetailsPage ({ location, data }) {
 
               <div className="col">
 
-                <p className="h2">
+                <p className="mt-5">
                   The last{" "}
                   <strong>{otherPrcnt}%</strong> of {placeTitle}'s climate pollution
                   comes from other sources...
@@ -807,23 +807,23 @@ export default function StateDetailsPage ({ location, data }) {
                   {/* All emojis in this context are decorative, so they are
                       marked with aria-hidden */}
                   <li>
-                    <span aria-hidden="true">🌾</span>
+                    <span className="mr-2" aria-hidden="true">🌾</span>
                     No-till farming to keep CO<sub>2</sub> in the soil
                   </li>
                   <li>
-                    <span aria-hidden="true">🗑️</span>
+                    <span className="mr-2" aria-hidden="true">🗑️</span>
                     Capturing methane leaks from landfills
                   </li>
                   <li>
-                    <span aria-hidden="true">🧱</span>
+                    <span className="mr-2" aria-hidden="true">🧱</span>
                     Capturing CO<sub>2</sub> to make emissions-free concrete
                   </li>
                   <li>
-                    <span aria-hidden="true">🔩</span>
+                    <span className="mr-2" aria-hidden="true">🔩</span>
                     Burning green hydrogen to make emissions-free steel
                   </li>
                   <li>
-                    <span aria-hidden="true">💨</span>
+                    <span className="mr-2" aria-hidden="true">💨</span>
                     Plugging methane leaks from gas pipelines
                   </li>
                 </ul>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -1,44 +1,44 @@
-import React, { useState } from "react";
-import { graphql, Link } from "gatsby";
-import Scrollspy from "react-scrollspy";
-import "react-bootstrap-table-next/dist/react-bootstrap-table2.min.css";
-import SingleBarChart from "../components/singlebar";
-import Layout from "../components/layout";
-import SEO from "../components/seo";
-import SimpleAreaChart from "../components/simpleareachart";
-import AlreadyElectrifiedChart from "./AlreadyElectrifiedChart";
-import DisplayPlants from "./displayplants.js";
-import WindSolarBuilds from "./WindSolarBuilds.js";
+import React, { useState } from "react"
+import { graphql, Link } from "gatsby"
+import Scrollspy from "react-scrollspy"
+import "react-bootstrap-table-next/dist/react-bootstrap-table2.min.css"
+import SingleBarChart from "../components/singlebar"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import SimpleAreaChart from "../components/simpleareachart"
+import AlreadyElectrifiedChart from "./AlreadyElectrifiedChart"
+import DisplayPlants from "./displayplants.js"
+import WindSolarBuilds from "./WindSolarBuilds.js"
 
 /**
  * Images - suffix with Img for clarity from actual JS files/variables
  */
 
-import CoalTransitionImg from "../images/coal-plant-transition.png";
+import CoalTransitionImg from "../images/coal-plant-transition.png"
 
 // Sim city power plant icons
-import OilPlantImg from "../images/oil-plant.png";
-import GasPlantImg from "../images/gas-plant.png";
-import CoalPlantImg from "../images/coal-plant.png";
-import PowerPlantMap from "../images/dirty-power-plants.jpg";
+import OilPlantImg from "../images/oil-plant.png"
+import GasPlantImg from "../images/gas-plant.png"
+import CoalPlantImg from "../images/coal-plant.png"
+import PowerPlantMap from "../images/dirty-power-plants.jpg"
 
 // New images
-import DirtyPowerPlantImg from "../images/dirty-power-plant.png";
+import DirtyPowerPlantImg from "../images/dirty-power-plant.png"
 
 const slugToTitle = (placeName) => {
-  const words = placeName.split("_");
+  const words = placeName.split("_")
 
   for (let i = 0; i < words.length; i++) {
-    const word = words[i];
+    const word = words[i]
     if (word === "of") {
-      words[i] = word;
+      words[i] = word
     } else {
-      words[i] = word.charAt(0).toUpperCase() + word.slice(1);
+      words[i] = word.charAt(0).toUpperCase() + word.slice(1)
     }
   }
 
-  return words.join(" ");
-};
+  return words.join(" ")
+}
 
 /**
  * Converts a very large number to a more readable string.
@@ -46,51 +46,51 @@ const slugToTitle = (placeName) => {
  * 2_114_602 -> '2.1 million'
  * 76_125 -> '76 thousand'
  */
-function numberToHumanString(num) {
+function numberToHumanString (num) {
   // Return clear error string if the number is null or undefined
   if (num === undefined || num === null) {
-    return "?";
+    return "?"
   }
 
   // If in the thousands, return '{rounded_num} thousands', e.g.76_126 ->
   // 76 thousand
   if (num > 1_000 && num < 1_000_000) {
-    return `${Math.round(num / 1_000)},000`;
+    return `${Math.round(num / 1_000)},000`
   }
   // If in the millions return '${rounded_num_one_decimal} millions', e.g.
   // 2_114_602 -> 2.1 million
   else if (num > 1_000_000 && num < 1_000_000_000) {
-    return `${(num / 1_000_000).toFixed(1)} million`;
+    return `${(num / 1_000_000).toFixed(1)} million`
   }
 
   // If in the hundreds or something else, return rounded to an integer
   // (e.g 534.451312 -> 534)
-  return Math.round(num);
+  return Math.round(num)
 }
 
-const currentYear = new Date().getFullYear();
+const currentYear = new Date().getFullYear()
 
 // The years we have till our zero goal of 20
-const yearsToTarget = 2050 - currentYear;
+const yearsToTarget = 2050 - currentYear
 
 // We want to get to 0 by 2050 and we use our current emissions as a start,
 // so the % to cut by is 100 divided by the number of years we have
-const cutPerYearPrcnt = (100 / yearsToTarget).toFixed(1);
+const cutPerYearPrcnt = (100 / yearsToTarget).toFixed(1)
 
-export default function StateDetailsPage({ location, data }) {
+export default function StateDetailsPage ({ location, data }) {
   /**
    * Properties to pass to the main desktop graph, which updates as you scroll
    */
   const [scrollGraphSettings, setScrollGraphSettings] = useState({
     active: "buildings",
     green: [],
-  });
+  })
 
   // place info and string
-  const currentPlace = location.pathname.split("/")[1];
+  const currentPlace = location.pathname.split("/")[1]
   // clean up title as needed
-  const placeTitle = slugToTitle(currentPlace);
-  const stateFaceClass = currentPlace.toLowerCase().replaceAll(" ", "-");
+  const placeTitle = slugToTitle(currentPlace)
+  const stateFaceClass = currentPlace.toLowerCase().replaceAll(" ", "-")
 
   // Each json loads in as an allSomethingJson and is filtered for
   // data relevant to this state, which is great!
@@ -98,76 +98,76 @@ export default function StateDetailsPage({ location, data }) {
   // so we can just take the first index
 
   // #### EMISSIONS ####
-  const emissionsByYear = data.allEmissionsJson.edges[0].node.emissionsByYear;
-  const latestEmissions = emissionsByYear[emissionsByYear.length - 1];
+  const emissionsByYear = data.allEmissionsJson.edges[0].node.emissionsByYear
+  const latestEmissions = emissionsByYear[emissionsByYear.length - 1]
   // desstructure out the different emissions categories for simplicity below
   const {
     buildings: buildingsEmissions,
     dirty_power: dirtyPowerEmissions,
     dumps_farms_industrial_other: farmsDumpsOtherEmissions,
     transportation: transportionEmissions,
-  } = latestEmissions;
+  } = latestEmissions
 
   // sum, then make nice percentages
   const sumOfEmissions =
     buildingsEmissions +
     dirtyPowerEmissions +
     farmsDumpsOtherEmissions +
-    transportionEmissions;
+    transportionEmissions
   const buildingsPrcnt = ((buildingsEmissions / sumOfEmissions) * 100).toFixed(
     0
-  );
-  const powerPrcnt = ((dirtyPowerEmissions / sumOfEmissions) * 100).toFixed(0);
+  )
+  const powerPrcnt = ((dirtyPowerEmissions / sumOfEmissions) * 100).toFixed(0)
   const transportPrcnt = (
     (transportionEmissions / sumOfEmissions) *
     100
-  ).toFixed(0);
+  ).toFixed(0)
   const otherPrcnt = (
     (farmsDumpsOtherEmissions / sumOfEmissions) *
     100
-  ).toFixed(0);
+  ).toFixed(0)
 
   const rawEmissionsCutPerYear = (sumOfEmissions * (1 / yearsToTarget)).toFixed(
     1
-  );
+  )
 
   // #### VEHICLES ####
   const { Cars_All: carsAll, EV_Registration: evRegistration } =
-    data.allVehiclesJson.edges[0].node;
+    data.allVehiclesJson.edges[0].node
 
-  const pctEv = Math.round((evRegistration / carsAll) * 100 * 10) / 10;
-  const pctNonEv = Math.round((100 - pctEv) * 10) / 10;
+  const pctEv = Math.round((evRegistration / carsAll) * 100 * 10) / 10
+  const pctNonEv = Math.round((100 - pctEv) * 10) / 10
 
   // calculate cars remaining to electrify
-  const carsToElectrify = carsAll - evRegistration;
+  const carsToElectrify = carsAll - evRegistration
 
   // string formatting
-  const carsCountStr = numberToHumanString(carsAll);
-  const carsToElectrifyStr = numberToHumanString(carsToElectrify);
+  const carsCountStr = numberToHumanString(carsAll)
+  const carsToElectrifyStr = numberToHumanString(carsToElectrify)
   const carsPerYear = numberToHumanString(
     Math.ceil((carsToElectrify * cutPerYearPrcnt) / 100)
-  );
-  const evCountStr = numberToHumanString(evRegistration);
+  )
+  const evCountStr = numberToHumanString(evRegistration)
 
   // #### BUILDINGS ####
   const { buildings, weightedFossilBuildingsPct, weightedEleBuildingsPct } =
-    data.allBuildingsJson.edges[0].node;
+    data.allBuildingsJson.edges[0].node
 
   // calculate buildings remaining to electrify
   const buildingsToElectrify =
     weightedEleBuildingsPct !== 0 || weightedFossilBuildingsPct !== 0
       ? buildings * (weightedFossilBuildingsPct / 100)
-      : buildings;
+      : buildings
 
   // string formatting
-  const buildingsCountStr = numberToHumanString(buildings);
-  const buildingsLeftToElectrifyStr = numberToHumanString(buildingsToElectrify);
+  const buildingsCountStr = numberToHumanString(buildings)
+  const buildingsLeftToElectrifyStr = numberToHumanString(buildingsToElectrify)
   const buildingsPerYear = numberToHumanString(
     Math.ceil((buildingsToElectrify * cutPerYearPrcnt) / 100)
-  );
+  )
 
   // #### SOLAR PANELS & WIND TURBINES ####
-  const targetBuilds = data.allTargetGenerationJson.edges[0].node;
+  const targetBuilds = data.allTargetGenerationJson.edges[0].node
 
   // deconstruct object for simplicity
   const {
@@ -177,113 +177,113 @@ export default function StateDetailsPage({ location, data }) {
     current_wind: currentWind,
     perc_solar_target: percSolarTarget,
     perc_wind_target: percWindTarget,
-  } = targetBuilds;
+  } = targetBuilds
 
   // since we are referencing capacity, let's stay consistent and make sure
   // everything is listed in MegaWatts... all of these numbers are in GigaWatts Hours
-  const everyDayPerYear = 24 * 365;
-  const targetGenBySolarMW = (targetGenBySolar / everyDayPerYear) * 1000;
-  const targetGenByWindMW = (targetGenByWind / everyDayPerYear) * 1000;
-  const currentSolarMW = (currentSolar / everyDayPerYear) * 1000;
-  const currentWindMW = (currentWind / everyDayPerYear) * 1000;
+  const everyDayPerYear = 24 * 365
+  const targetGenBySolarMW = (targetGenBySolar / everyDayPerYear) * 1000
+  const targetGenByWindMW = (targetGenByWind / everyDayPerYear) * 1000
+  const currentSolarMW = (currentSolar / everyDayPerYear) * 1000
+  const currentWindMW = (currentWind / everyDayPerYear) * 1000
 
   // Clamp to zero since if we never want to say negative solar needs to be
   // built
   const solarPanelsBuildPerYear = Math.max(
     0,
     Math.round((targetGenBySolarMW - currentSolarMW) / yearsToTarget)
-  );
+  )
   const windTurbinesBuildPerYear = Math.max(
     0,
     Math.round((targetGenByWindMW - currentWindMW) / yearsToTarget)
-  );
+  )
 
   // getting percentages for chart
   // Note that we divide in half since 100% solar and 100% wind is 100% of total
   // not 200%
-  const percToCleanTarget = percSolarTarget + percWindTarget / 2;
-  const totalRemaining = 100 - percToCleanTarget;
+  const percToCleanTarget = percSolarTarget + percWindTarget / 2
+  const totalRemaining = 100 - percToCleanTarget
 
   // converting values to strings
   const solarPanelsCountStr =
     targetGenBySolarMW !== undefined
       ? numberToHumanString(targetGenBySolarMW)
-      : "?";
+      : "?"
   const windTurbinesCountStr =
     targetGenByWindMW !== undefined
       ? numberToHumanString(targetGenByWindMW)
-      : "?";
+      : "?"
   const solarPanelsBuildPerYearStr =
     targetGenBySolarMW !== undefined
       ? numberToHumanString(solarPanelsBuildPerYear)
-      : "?";
+      : "?"
   const windTurbinesBuildPerYearStr =
     targetGenByWindMW !== undefined
       ? numberToHumanString(windTurbinesBuildPerYear)
-      : "?";
+      : "?"
 
-  const currentSolarMWStr = numberToHumanString(currentSolarMW);
-  const currentWindMWStr = numberToHumanString(currentWindMW);
+  const currentSolarMWStr = numberToHumanString(currentSolarMW)
+  const currentWindMWStr = numberToHumanString(currentWindMW)
 
   // #### POWER PLANTS ####
-  const powerPlants = data.allPowerPlantsJson.edges[0].node.power_plants;
+  const powerPlants = data.allPowerPlantsJson.edges[0].node.power_plants
 
-  powerPlants.sort((a, b) => b.capacity_mw - a.capacity_mw);
+  powerPlants.sort((a, b) => b.capacity_mw - a.capacity_mw)
 
   const coalPlants = powerPlants.filter(
     (plant) => plant.fossil_fuel_category === "COAL"
-  );
+  )
   const gasPlants = powerPlants.filter(
     (plant) => plant.fossil_fuel_category === "GAS"
-  );
+  )
   const oilPlants = powerPlants.filter(
     (plant) => plant.fossil_fuel_category === "OIL"
-  );
+  )
 
-  function scrollTargetUpdated(scrollTarget) {
-    let activeKey = "buildings";
-    let greenKeys = [];
+  function scrollTargetUpdated (scrollTarget) {
+    let activeKey = "buildings"
+    let greenKeys = []
 
     // Make sure we don't try using the scrollTarget if it's null
     if (!scrollTarget) {
-      return;
+      return
     }
 
-    const targetId = scrollTarget.id;
+    const targetId = scrollTarget.id
 
     if (!targetId) {
-      console.error("Scroll target had no ID! Element was:", scrollTarget);
-      setScrollGraphSettings({ active: activeKey, green: greenKeys });
-      return;
+      console.error("Scroll target had no ID! Element was:", scrollTarget)
+      setScrollGraphSettings({ active: activeKey, green: greenKeys })
+      return
     }
 
     if (targetId === "bld-main") {
-      activeKey = "buildings";
-      greenKeys = [];
+      activeKey = "buildings"
+      greenKeys = []
     } else if (targetId === "bld-end") {
-      activeKey = "";
-      greenKeys = ["buildings"];
+      activeKey = ""
+      greenKeys = ["buildings"]
     } else if (targetId === "transport-main") {
-      activeKey = "transportation";
-      greenKeys = ["buildings"];
+      activeKey = "transportation"
+      greenKeys = ["buildings"]
     } else if (targetId === "transport-end") {
-      activeKey = "";
-      greenKeys = ["buildings", "transportation"];
+      activeKey = ""
+      greenKeys = ["buildings", "transportation"]
     } else if (targetId === "power-main") {
-      activeKey = "dirty_power";
-      greenKeys = ["buildings", "transportation"];
+      activeKey = "dirty_power"
+      greenKeys = ["buildings", "transportation"]
     } else if (targetId === "power-end") {
-      activeKey = "";
-      greenKeys = ["buildings", "transportation", "dirty_power"];
+      activeKey = ""
+      greenKeys = ["buildings", "transportation", "dirty_power"]
     } else if (targetId === "other-main") {
-      activeKey = "dumps_farms_industrial_other";
-      greenKeys = ["buildings", "transportation", "dirty_power"];
+      activeKey = "dumps_farms_industrial_other"
+      greenKeys = ["buildings", "transportation", "dirty_power"]
     }
 
-    setScrollGraphSettings({ active: activeKey, green: greenKeys });
+    setScrollGraphSettings({ active: activeKey, green: greenKeys })
   }
   // Description will retain formatting, so this needs to be single line
-  const descriptionText = `To get to zero by 2050, ${placeTitle} must cut climate pollution by ${cutPerYearPrcnt}% a year. Electrification can help us get there.`;
+  const descriptionText = `To get to zero by 2050, ${placeTitle} must cut climate pollution by ${cutPerYearPrcnt}% a year. Electrification can help us get there.`
 
   return (
     <Layout>
@@ -871,7 +871,7 @@ export default function StateDetailsPage({ location, data }) {
         </Link>
       </section>
     </Layout>
-  );
+  )
 }
 
 export const query = graphql`
@@ -932,4 +932,4 @@ export const query = graphql`
       }
     }
   }
-`;
+`

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -417,7 +417,7 @@ export default function StateDetailsPage ({ location, data }) {
             </p>
 
             <p className="mt-6">We'll replace...</p>
-            <p className="mt-4 mb-4">
+            <div className="mt-4 mb-4">
               <ul>
                 <li>
                   Boilers and furnaces with{" "}
@@ -440,7 +440,7 @@ export default function StateDetailsPage ({ location, data }) {
                   </a>
                 </li>
               </ul>
-            </p>
+            </div>
 
             <div className="d-flex align-items-end justify-content-between flex-wrap  mt-5 mb-5">
               <div className="appliance-sheet -stove -clean"></div>
@@ -857,7 +857,7 @@ export default function StateDetailsPage ({ location, data }) {
 
       <section className="text-center mb-8">
         {/* This emoji is purely decorative */}
-        <div class="h1 mt-7 mb-3">
+        <div className="h1 mt-7 mb-3">
           <span aria-hidden="true">✅</span>
         </div>
         <h2 className="h1 font-weight-bold">Ready to do your part?</h2>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -382,9 +382,9 @@ export default function StateDetailsPage ({ location, data }) {
                   activeKey={"buildings"}
                 />
               </div>
-              <div className="col h3">
+              <div className="col">
 
-                <p className="h2 mt-2 mb-0">
+                <p className="mt-2 mb-0">
                   <strong>{buildingsPrcnt}%</strong>{" "}
                   of {placeTitle}'s climate pollution comes from buildings.
                 </p>
@@ -396,7 +396,7 @@ export default function StateDetailsPage ({ location, data }) {
               </div>
             </div>
 
-            <p className="h2 mt-6 mb-0">
+            <p className="mt-6 mb-0">
               {/* Sourced from Rewiring America Electrify Everything in Your Home guide */}
               We burn <strong>fossil fuels</strong> to <strong>heat</strong> our air, water, and food.
             </p>
@@ -407,18 +407,18 @@ export default function StateDetailsPage ({ location, data }) {
               <div className="appliance-sheet -heater"></div>
             </div>
 
-            <p className="h2 mt-6">
+            <p className="mt-6">
             To <strong>cut</strong> this pollution...
             </p>
 
-            <p className="h2 mt-4 mb-6 text-right">
+            <p className="mt-4 mb-6 text-right">
               Let's <strong>electrify</strong> our <strong>heat</strong>!
             </p>
 
-            <p className="h2 mt-6">
+            <p className="mt-6">
               We'll replace...
             </p>
-            <p className="h3 mt-4 mb-4">
+            <p className="mt-4 mb-4">
               <ul>
                 <li>
                   Boilers and furnaces with {" "}
@@ -449,7 +449,7 @@ export default function StateDetailsPage ({ location, data }) {
               <div className="appliance-sheet -heater -clean"></div>
             </div>
 
-            <p className="h2 mt-0 mb-4 text-right">
+            <p className="mt-0 mb-4 text-right">
               ...in all of {placeTitle}'s <strong>{buildingsCountStr} buildings</strong>.
             </p>
 
@@ -460,13 +460,13 @@ export default function StateDetailsPage ({ location, data }) {
 
             {(weightedEleBuildingsPct !== 0 ||
               weightedFossilBuildingsPct !== 0) && (
-              <p className="h3 mt-8">
+              <p className="mt-8">
                 In fact, {Math.round(weightedEleBuildingsPct)}% of buildings
                 in {placeTitle} are already fossil fuel free!
               </p>
             )}
 
-            <p className="h3 mt-5">
+            <p className="mt-5">
               That means we only need to electrify the remaining{" "}
               {buildingsLeftToElectrifyStr} buildings in {placeTitle}.{" "}
               That's around {buildingsPerYear} per year.
@@ -480,7 +480,7 @@ export default function StateDetailsPage ({ location, data }) {
 
           <div id="bld-end" className="scrollable-sect mt-8 mb-4">
             <p className="h1 font-weight-bold text-center mt-6 mb-6">
-              That cuts {buildingsPrcnt}% of the pollution.
+              Electrifying all buildings cuts {buildingsPrcnt}% of the pollution.
             </p>
 
             <div className="mt-4 d-flex justify-content-center d-block d-xl-none">
@@ -490,7 +490,7 @@ export default function StateDetailsPage ({ location, data }) {
               />
             </div>
 
-            <hr className="mb-8" />
+            <hr className="d-xl-none mb-8" />
           </div>
 
           {/* Transportation Section */}
@@ -507,11 +507,11 @@ export default function StateDetailsPage ({ location, data }) {
                 />
               </div>
 
-              <div className="col h3">
-                <p className="h2 mt-2">
+              <div className="col">
+                <p className="mt-2">
                   <strong>{transportPrcnt}%</strong> of {placeTitle}'s
                   pollution comes from cars, trucks, trains, and planes.</p>
-                <p className="h2 mt-6 mb-6 text-right">
+                <p className="mt-6 mb-6 text-right">
                   But <strong>mostly</strong> from cars.
                 </p>
               </div>
@@ -523,11 +523,11 @@ export default function StateDetailsPage ({ location, data }) {
               <div className="col-8 car-sheet -semi mt-5"></div>
             </div>
 
-            <p className="h2 mt-6">
+            <p className="mt-6">
               To cut this pollution,
             </p>
 
-            <p className="h2 mt-4 mb-5 text-right">
+            <p className="mt-4 mb-5 text-right">
               your next car must be <strong>electric</strong>.
             </p>
 
@@ -536,7 +536,7 @@ export default function StateDetailsPage ({ location, data }) {
               share, or other alternatives!
             </p>
 
-            <p className="h2 mt-8">
+            <p className="mt-8">
               Then, we'll electrify all <strong>{carsCountStr} cars and trucks</strong> in{" "}
               {placeTitle}!
             </p>
@@ -563,7 +563,7 @@ export default function StateDetailsPage ({ location, data }) {
 
           <div id="transport-end" className="scrollable-sect mt-8 mb-4">
             <p className="h1 font-weight-bold text-center mt-6 mb-6">
-              That cuts {transportPrcnt}% of the pollution.
+              Electrifying all transportation cuts {transportPrcnt}% of the pollution.
             </p>
 
             <div className="mt-4 d-flex justify-content-center d-block d-xl-none">
@@ -573,7 +573,7 @@ export default function StateDetailsPage ({ location, data }) {
               />
             </div>
 
-            <hr className="mt-8" />
+            <hr className="d-xl-none mt-8" />
           </div>
 
           {/* Power Section */}
@@ -593,7 +593,7 @@ export default function StateDetailsPage ({ location, data }) {
                 </div>
 
                 <div className="col">
-                  <p className="h2 mt-2">
+                  <p className="mt-2">
                     <strong>{powerPrcnt}%</strong> of {placeTitle}'s
                     pollution comes from burning <strong>coal</strong>, <strong>gas</strong>, and <strong>oil</strong> to
                     make power.
@@ -609,11 +609,11 @@ export default function StateDetailsPage ({ location, data }) {
                 </div>
               </div>
 
-              <p className="h2 mt-6">
+              <p className="mt-6">
               To cut this pollution...
               </p>
 
-              <p className="h2 mt-4 mb-6 text-right">
+              <p className="mt-4 mb-6 text-right">
                 Put <strong>solar panels</strong> on your roof!
               </p>
 
@@ -621,7 +621,7 @@ export default function StateDetailsPage ({ location, data }) {
                 <div className="building-sheet -house -clean col-8"></div>
               </div>
 
-              <p className="h2 mt-8">
+              <p className="mt-8">
                 Then, we'll replace <strong>all fossil fuel power plants</strong> with solar and wind farms.
               </p>
 
@@ -636,7 +636,7 @@ export default function StateDetailsPage ({ location, data }) {
                 />
               </p>
 
-              <p className="h3 mt-5 mb-8">
+              <p className="mt-5 mb-8">
                 ...and find good jobs for those workers.
               </p>
 
@@ -644,7 +644,7 @@ export default function StateDetailsPage ({ location, data }) {
 
               {coalPlants.length > 0 && (
                 <>
-                  <p className="h3 mt-5">
+                  <p className="mt-5">
                     <strong>
                       {coalPlants.length} coal plant
                       {coalPlants.length !== 1 && "s"}{" "}
@@ -659,7 +659,7 @@ export default function StateDetailsPage ({ location, data }) {
 
               {gasPlants.length > 0 && (
                 <>
-                  <p className="h3 mt-5">
+                  <p className="mt-5">
                     <strong>
                       {gasPlants.length} gas plant
                       {gasPlants.length !== 1 && "s"}
@@ -671,7 +671,7 @@ export default function StateDetailsPage ({ location, data }) {
 
               {oilPlants.length > 0 && (
                 <>
-                  <p className="h3 mt-5">
+                  <p className="mt-5">
                     <strong>
                       {oilPlants.length} oil plant
                       {oilPlants.length !== 1 && "s"}
@@ -696,24 +696,24 @@ export default function StateDetailsPage ({ location, data }) {
                 </div>
               </div>
 
-              <p className="h2 mt-8">
+              <p className="mt-8">
                 But wait!
               </p>
 
-              <p className="h2 mt-6">
+              <p className="mt-6">
                 It's not enough to replace our power plants with wind and solar farms.
               </p>
 
-              <p className="h2 mt-6">
+              <p className="mt-6">
                 To power our electric cars and buildings, we need <strong>2x</strong> the electricity we have today!
               </p>
 
-              <p className="h2 mt-8">
+              <p className="mt-6">
                 In all, we'll need to build <strong>{windTurbinesCountStr} MWs</strong> of wind
                 and <strong>{solarPanelsCountStr} MWs</strong> of solar.
               </p>
 
-              <p className="h3 mt-5">
+              <p className="mt-5">
                 Since {placeTitle} already has {currentSolarMWStr} megawatts of
                 solar power generation and {currentWindMWStr} megawatts of wind
                 power generation, that's{" "}
@@ -736,9 +736,9 @@ export default function StateDetailsPage ({ location, data }) {
           {powerPrcnt > 0 && (
             <div id="power-end" className="scrollable-sect mt-8 mb-4">
               <p className="h1 font-weight-bold text-center mt-6 mb-6">
-                That cuts {powerPrcnt}% of the pollution.
+                Decarbonizing all dirty power cuts {powerPrcnt}% of the pollution.
               </p>
-              <p className="h2 text-center mt-6 mb-6">
+              <p className="text-center mt-6 mb-6">
                 And gives us zero-emissions power we need to eliminate pollution
                 from buildings and cars!
               </p>
@@ -750,7 +750,7 @@ export default function StateDetailsPage ({ location, data }) {
                 />
               </div>
 
-              <hr className="mt-7" />
+              <hr className="d-xl-none mt-7" />
             </div>
           )}
 
@@ -759,7 +759,7 @@ export default function StateDetailsPage ({ location, data }) {
             <div id="power-main" className="scrollable-sect mt-5 mb-7">
               <h2 className="h1">Power</h2>
               <div className="mt-6 mb-8 text-center">
-                <p className="h3 font-weight-bold">
+                <p className="font-weight-bold">
                   {placeTitle} produces all of it's power without making any climate pollution! 😎
                 </p>
 
@@ -768,7 +768,7 @@ export default function StateDetailsPage ({ location, data }) {
                   emissions to zero.
                 </p>
 
-                <hr className="mt-7" />
+                <hr className="d-xl-none mt-7" />
               </div>
             </div>
           )}
@@ -794,7 +794,7 @@ export default function StateDetailsPage ({ location, data }) {
                   <strong>{otherPrcnt}%</strong> of {placeTitle}'s climate pollution
                   comes from other sources...
                 </p>
-                <p className="h2 mt-5">
+                <p className="mt-5">
                   This includes farming, landfills, industry, and leaks from gas pipelines.
                 </p>
 
@@ -833,7 +833,7 @@ export default function StateDetailsPage ({ location, data }) {
         </Scrollspy>
       </div>
 
-      <hr className="mt-7" />
+      <hr className="d-xl-none mt-7" />
 
       <section className="text-center mb-8">
         {/* This emoji is purely decorative */}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,8 @@
 /* Import stateface for state icons */
 @import 'stateface/stateface.css';
-@import 'index.css';
 @import 'social-card.css';
+@import 'index.css';
+@import 'state-details.css';
 
 /** Import Lato Google font with specific weights */
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,500;0,700;0,900;1,400&display=swap');
@@ -271,51 +272,6 @@ footer a {
 
 @media (max-width: 991px) {
     .single-bar-chart tspan { font-size: 0.8rem; }
-}
-
-.sticky-header {
-    position: sticky;
-    top: 55px; /* align with site header */
-    background-color: #fff;
-    z-index: 10;
-    border-bottom: solid 1px gainsboro;
-    /* Ick, I know. Blame Bootstrap for negative margins */
-    margin-left: -15px;
-    margin-right: -15px;
-    padding: 0.5rem 1rem;
-}
-
-/**
- * State Details Page - full desktop sticky graph layout
- */
-@media (min-width: 1200px) {
-    .sticky-header h1 .title { font-size: 2rem !important; }
-
-    /* On desktop, don't apply margin to row elements, since they don't
-       on the big screen layout anything */
-    .state-details-main .row { margin-top: 0 !important; }
-
-    /** Add transparent border to all sections so we can animate it in without
-     * shifting content */
-    .state-details-main .scrollable-sect {
-        padding: 2rem 0 2rem 2rem;
-        border-left: solid transparent 0.5rem;
-        transition: border-color 0.4s;
-    }
-
-    /*
-     * Style the active section.
-     *
-     * NOTE: The last section never gets the .is-current class for some reason, so use the
-     * sibling selector to make sure it is faded in after the previous one is
-     * scrolled-past
-     */
-    .state-details-main .scrollable-sect.is-current,
-    .state-details-main div#power-end.scrolled-past + div {
-        border-color: #ff5722;
-    }
-
-     { opacity: 1 !important; }
 }
 
 /**

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -1,0 +1,54 @@
+/**
+ * State Details page styling
+ */
+
+.state-details-main .sticky-header {
+    position: sticky;
+    top: 55px; /* align with site header */
+    background-color: #fff;
+    z-index: 10;
+    border-bottom: solid 1px gainsboro;
+    /* Ick, I know. Blame Bootstrap for negative margins */
+    margin-left: -15px;
+    margin-right: -15px;
+    padding: 0.5rem 1rem;
+}
+
+/**
+ * Set consistent paragraph styles to keep text size uniform unless a paragraph
+ * specifically should be bigger or smaller
+ */
+.state-details-main p:not(.h1, .h2, .h3, .h4, .h5, .h6) {
+    font-size: 1.75rem;
+}
+
+/**
+ * Desktop Styling - full desktop sticky graph layout
+ */
+@media (min-width: 1200px) {
+    .state-details-main .sticky-header h1 .title { font-size: 2rem !important; }
+
+    /* On desktop, don't apply margin to row elements, since they don't
+       on the big screen layout anything */
+    .state-details-main .row { margin-top: 0 !important; }
+
+    /** Add transparent border to all sections so we can animate it in without
+     * shifting content */
+    .state-details-main .scrollable-sect {
+        padding: 2rem 0 2rem 2rem;
+        border-left: solid transparent 0.5rem;
+        transition: border-color 0.4s;
+    }
+
+    /*
+     * Style the active section.
+     *
+     * NOTE: The last section never gets the .is-current class for some reason, so use the
+     * sibling selector to make sure it is faded in after the previous one is
+     * scrolled-past
+     */
+    .state-details-main .scrollable-sect.is-current,
+    .state-details-main div#power-end.scrolled-past + div {
+        border-color: #ff5722;
+    }
+}

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -2,7 +2,7 @@
  * State Details page styling
  */
 
-.state-details-main .sticky-header {
+.sticky-header {
     position: sticky;
     top: 55px; /* align with site header */
     background-color: #fff;
@@ -26,7 +26,7 @@
  * Desktop Styling - full desktop sticky graph layout
  */
 @media (min-width: 1200px) {
-    .state-details-main .sticky-header h1 .title { font-size: 2rem !important; }
+    .sticky-header h1 .title { font-size: 2rem !important; }
 
     /* On desktop, don't apply margin to row elements, since they don't
        on the big screen layout anything */

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -22,6 +22,17 @@
     font-size: 1.75rem;
 }
 
+/** Add padding between bulleted list items */
+.state-details-main li + li { margin-top: 1em; }
+
+/**
+ * Mobile/tablet styling - shrink some text
+ */
+@media (max-width: 1199px) {
+    /* Shrink .h1 text */
+    .h1 { font-size: 1.75rem; }
+}
+
 /**
  * Desktop Styling - full desktop sticky graph layout
  */
@@ -38,6 +49,21 @@
         padding: 2rem 0 2rem 2rem;
         border-left: solid transparent 0.5rem;
         transition: border-color 0.4s;
+    }
+
+
+    /**
+     * Have the "Decarbonising X cuts Y% of the pollution" faded out until you
+     * scroll into it, giving it a bit of a pop
+     */
+    .state-details-main .change-text p {
+        opacity: 0.2;
+        transition: opacity 0.5s;
+    }
+
+    .state-details-main .change-text.is-current p,
+    .state-details-main .change-text.scrolled-past p {
+        opacity: 1;
     }
 
     /*

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -51,21 +51,6 @@
         transition: border-color 0.4s;
     }
 
-
-    /**
-     * Have the "Decarbonising X cuts Y% of the pollution" faded out until you
-     * scroll into it, giving it a bit of a pop
-     */
-    .state-details-main .change-text p {
-        opacity: 0.2;
-        transition: opacity 0.5s;
-    }
-
-    .state-details-main .change-text.is-current p,
-    .state-details-main .change-text.scrolled-past p {
-        opacity: 1;
-    }
-
     /*
      * Style the active section.
      *


### PR DESCRIPTION
## Overview

Fixes issues with my latest state details page, like tight spacing and duplicate images (which I think was caused by a React HTML error)

This also includes some improvements to the wording and spacing of the sections that say how much pollution is dropped. I made the text clarify _what_ dropped the emissions (more clear, more screen-shottable) and experimentally made them fade in for emphasis:

| Before | After |
| --- | --- |
|  ![Screenshot from 2022-08-28 21-31-43](https://user-images.githubusercontent.com/3187531/187112618-70fe2ee8-ef60-46f7-a028-b25533199093.png) | ![Screenshot from 2022-08-28 21-31-54](https://user-images.githubusercontent.com/3187531/187112854-d4aed1e8-3bc0-4a62-a6fa-2026c6ae6643.png) |

Fade In Text Demo:

![Peek 2022-08-28 21-41](https://user-images.githubusercontent.com/3187531/187112774-7fb2fa87-c1c6-4e09-a399-5b9368a595d0.gif)

**Note:** I just tacked in the fade in behavior. If folks don't like it, let me know and I can remove it!

Closes #148

### Demo

See description.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Test the state details page on mobile and desktop, confirming spacing is never too tight (with elements touching) and all images are what you expect