### PR TITLE
source citation for charts

### DIFF
--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -230,7 +230,7 @@ const ChoroplethMap = ({
             </div>
             <br />
             <span className="text-secondary keyText">
-              Source: { getShortCitation("emissions") }
+              Source: {getShortCitation("emissions")}
             </span>
           </Col>
         ) : null}

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -199,7 +199,7 @@ const ChoroplethMap = ({
         {emissions && sidebar ? (
           <Col lg={3} className="map-legend">
             <div className="h6 mt-4 font-weight-bold">
-              Climate pollution in 2018
+              Climate pollution
             </div>
             <div className="legendKey">
               <span className="keyText">
@@ -229,6 +229,7 @@ const ChoroplethMap = ({
               <span className="keyColor choroplethNull"></span>
               <span className="keyText">Data not available</span>
             </div>
+            <br /><span className="text-secondary keyText">Source: World Resource Institute, 2018</span>
           </Col>
         ) : null}
         <Col lg={{ span: sidebar ? 9 : 12 }}>

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -5,6 +5,7 @@ import { navigate } from "gatsby"
 
 import USMap from "../images/svg/usaStatesNoTerritories.js"
 import jenks from "./jenks"
+import { getShortCitation } from "../constants/source-citations.js"
 
 function CustomHover({ emissions, activeRegion }) {
   if (emissions[activeRegion.id] != null) {
@@ -229,7 +230,7 @@ const ChoroplethMap = ({
             </div>
             <br />
             <span className="text-secondary keyText">
-              Source: World Resource Institute, 2018
+              Source: { getShortCitation("emissions") }
             </span>
           </Col>
         ) : null}

--- a/src/components/choroplethmap.js
+++ b/src/components/choroplethmap.js
@@ -198,9 +198,7 @@ const ChoroplethMap = ({
       <Row className="map-row">
         {emissions && sidebar ? (
           <Col lg={3} className="map-legend">
-            <div className="h6 mt-4 font-weight-bold">
-              Climate pollution
-            </div>
+            <div className="h6 mt-4 font-weight-bold">Climate pollution</div>
             <div className="legendKey">
               <span className="keyText">
                 in millions of metric tons of CO2e
@@ -229,7 +227,10 @@ const ChoroplethMap = ({
               <span className="keyColor choroplethNull"></span>
               <span className="keyText">Data not available</span>
             </div>
-            <br /><span className="text-secondary keyText">Source: World Resource Institute, 2018</span>
+            <br />
+            <span className="text-secondary keyText">
+              Source: World Resource Institute, 2018
+            </span>
           </Col>
         ) : null}
         <Col lg={{ span: sidebar ? 9 : 12 }}>

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -336,6 +336,7 @@ export default function StateDetailsPage({ location, data }) {
         <p className="small">
           <strong>Note:</strong> Grey area indicates missing data due to
           processing delays.
+          <br /><span className="text-secondary">Source: World Resource Institute, 2018</span>
         </p>
         <SimpleAreaChart
           emissionsData={emissionsByYear}
@@ -365,6 +366,7 @@ export default function StateDetailsPage({ location, data }) {
             activeKey={scrollGraphSettings.active}
             greenKeys={scrollGraphSettings.green}
           />
+          <br /><span className="text-secondary keyText">Source: World Resource Institute, 2018</span>
         </div>
 
         {/*
@@ -493,6 +495,7 @@ export default function StateDetailsPage({ location, data }) {
               electrifiedPct={weightedEleBuildingsPct}
               fossilPct={weightedFossilBuildingsPct}
             />
+            <span className="mt-4 text-secondary keyText">Source: Microsoft Maps, Mar 2021; National Renewable Energy Laboratory (NREL), Dec 2021</span>
           </div>
 
           <div id="bld-end" className="scrollable-sect change-text mt-8 mb-4">
@@ -576,6 +579,7 @@ export default function StateDetailsPage({ location, data }) {
               electrifiedPct={pctEv}
               fossilPct={pctNonEv}
             />
+            <span className="mt-4 text-secondary keyText">Source: U.S. Department of Transportation (DOT), Feb 2021</span>
           </div>
 
           <div
@@ -719,6 +723,7 @@ export default function StateDetailsPage({ location, data }) {
                   </a>
                 </div>
               </div>
+              <span className="mt-4 text-secondary keyText">Source: U.S. Environmental Protection Agency (EPA), Feb 2021</span>
 
               <p className="mt-8">But wait!</p>
 
@@ -757,6 +762,7 @@ export default function StateDetailsPage({ location, data }) {
                   percentRemaining={totalRemaining}
                 />
               </p>
+              <span className="mt-4 text-secondary keyText">Source: U.S. Energy Information Administration (EIA), Apr 2022</span>
             </div>
           )}
           {/* Show standard outro section if power emissions are non-zero */}

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -9,6 +9,7 @@ import SimpleAreaChart from "../components/simpleareachart"
 import AlreadyElectrifiedChart from "./AlreadyElectrifiedChart"
 import DisplayPlants from "./displayplants.js"
 import WindSolarBuilds from "./WindSolarBuilds.js"
+import { getShortCitation } from "../constants/source-citations.js"
 
 /**
  * Images - suffix with Img for clarity from actual JS files/variables
@@ -338,7 +339,7 @@ export default function StateDetailsPage({ location, data }) {
           processing delays.
           <br />
           <span className="text-secondary">
-            Source: World Resource Institute, 2018
+            Source: { getShortCitation("emissions") }
           </span>
         </p>
         <SimpleAreaChart
@@ -371,7 +372,7 @@ export default function StateDetailsPage({ location, data }) {
           />
           <br />
           <span className="text-secondary keyText">
-            Source: World Resource Institute, 2018
+            Source: { getShortCitation("emissions") }
           </span>
         </div>
 
@@ -502,8 +503,7 @@ export default function StateDetailsPage({ location, data }) {
               fossilPct={weightedFossilBuildingsPct}
             />
             <span className="mt-4 text-secondary keyText">
-              Source: Microsoft Maps, Mar 2021; National Renewable Energy
-              Laboratory (NREL), Dec 2021
+              Source: { getShortCitation("building-footprints") }; { getShortCitation("building-energy") }
             </span>
           </div>
 
@@ -589,7 +589,7 @@ export default function StateDetailsPage({ location, data }) {
               fossilPct={pctNonEv}
             />
             <span className="mt-4 text-secondary keyText">
-              Source: U.S. Department of Transportation (DOT), Feb 2021
+              Source: { getShortCitation("vehicles") }
             </span>
           </div>
 
@@ -735,7 +735,7 @@ export default function StateDetailsPage({ location, data }) {
                 </div>
               </div>
               <span className="mt-4 text-secondary keyText">
-                Source: U.S. Environmental Protection Agency (EPA), Feb 2021
+                Source: { getShortCitation("power-plants") }
               </span>
 
               <p className="mt-8">But wait!</p>
@@ -776,7 +776,7 @@ export default function StateDetailsPage({ location, data }) {
                 />
               </p>
               <span className="mt-4 text-secondary keyText">
-                Source: U.S. Energy Information Administration (EIA), Apr 2022
+                Source: { getShortCitation("power-generation") }
               </span>
             </div>
           )}

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -339,7 +339,7 @@ export default function StateDetailsPage({ location, data }) {
           processing delays.
           <br />
           <span className="text-secondary">
-            Source: { getShortCitation("emissions") }
+            Source: {getShortCitation("emissions")}
           </span>
         </p>
         <SimpleAreaChart
@@ -372,7 +372,7 @@ export default function StateDetailsPage({ location, data }) {
           />
           <br />
           <span className="text-secondary keyText">
-            Source: { getShortCitation("emissions") }
+            Source: {getShortCitation("emissions")}
           </span>
         </div>
 
@@ -503,7 +503,8 @@ export default function StateDetailsPage({ location, data }) {
               fossilPct={weightedFossilBuildingsPct}
             />
             <span className="mt-4 text-secondary keyText">
-              Source: { getShortCitation("building-footprints") }; { getShortCitation("building-energy") }
+              Source: {getShortCitation("building-footprints")};{" "}
+              {getShortCitation("building-energy")}
             </span>
           </div>
 
@@ -589,7 +590,7 @@ export default function StateDetailsPage({ location, data }) {
               fossilPct={pctNonEv}
             />
             <span className="mt-4 text-secondary keyText">
-              Source: { getShortCitation("vehicles") }
+              Source: {getShortCitation("vehicles")}
             </span>
           </div>
 
@@ -735,7 +736,7 @@ export default function StateDetailsPage({ location, data }) {
                 </div>
               </div>
               <span className="mt-4 text-secondary keyText">
-                Source: { getShortCitation("power-plants") }
+                Source: {getShortCitation("power-plants")}
               </span>
 
               <p className="mt-8">But wait!</p>
@@ -776,7 +777,7 @@ export default function StateDetailsPage({ location, data }) {
                 />
               </p>
               <span className="mt-4 text-secondary keyText">
-                Source: { getShortCitation("power-generation") }
+                Source: {getShortCitation("power-generation")}
               </span>
             </div>
           )}

--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -336,7 +336,10 @@ export default function StateDetailsPage({ location, data }) {
         <p className="small">
           <strong>Note:</strong> Grey area indicates missing data due to
           processing delays.
-          <br /><span className="text-secondary">Source: World Resource Institute, 2018</span>
+          <br />
+          <span className="text-secondary">
+            Source: World Resource Institute, 2018
+          </span>
         </p>
         <SimpleAreaChart
           emissionsData={emissionsByYear}
@@ -366,7 +369,10 @@ export default function StateDetailsPage({ location, data }) {
             activeKey={scrollGraphSettings.active}
             greenKeys={scrollGraphSettings.green}
           />
-          <br /><span className="text-secondary keyText">Source: World Resource Institute, 2018</span>
+          <br />
+          <span className="text-secondary keyText">
+            Source: World Resource Institute, 2018
+          </span>
         </div>
 
         {/*
@@ -495,7 +501,10 @@ export default function StateDetailsPage({ location, data }) {
               electrifiedPct={weightedEleBuildingsPct}
               fossilPct={weightedFossilBuildingsPct}
             />
-            <span className="mt-4 text-secondary keyText">Source: Microsoft Maps, Mar 2021; National Renewable Energy Laboratory (NREL), Dec 2021</span>
+            <span className="mt-4 text-secondary keyText">
+              Source: Microsoft Maps, Mar 2021; National Renewable Energy
+              Laboratory (NREL), Dec 2021
+            </span>
           </div>
 
           <div id="bld-end" className="scrollable-sect change-text mt-8 mb-4">
@@ -579,7 +588,9 @@ export default function StateDetailsPage({ location, data }) {
               electrifiedPct={pctEv}
               fossilPct={pctNonEv}
             />
-            <span className="mt-4 text-secondary keyText">Source: U.S. Department of Transportation (DOT), Feb 2021</span>
+            <span className="mt-4 text-secondary keyText">
+              Source: U.S. Department of Transportation (DOT), Feb 2021
+            </span>
           </div>
 
           <div
@@ -723,7 +734,9 @@ export default function StateDetailsPage({ location, data }) {
                   </a>
                 </div>
               </div>
-              <span className="mt-4 text-secondary keyText">Source: U.S. Environmental Protection Agency (EPA), Feb 2021</span>
+              <span className="mt-4 text-secondary keyText">
+                Source: U.S. Environmental Protection Agency (EPA), Feb 2021
+              </span>
 
               <p className="mt-8">But wait!</p>
 
@@ -762,7 +775,9 @@ export default function StateDetailsPage({ location, data }) {
                   percentRemaining={totalRemaining}
                 />
               </p>
-              <span className="mt-4 text-secondary keyText">Source: U.S. Energy Information Administration (EIA), Apr 2022</span>
+              <span className="mt-4 text-secondary keyText">
+                Source: U.S. Energy Information Administration (EIA), Apr 2022
+              </span>
             </div>
           )}
           {/* Show standard outro section if power emissions are non-zero */}

--- a/src/constants/source-citations.js
+++ b/src/constants/source-citations.js
@@ -1,11 +1,11 @@
 import React from "react"
 
-export function getShortCitation(slug){
+export function getShortCitation(slug) {
   const citation = getCitation(slug)
   return `${citation.source_short}, ${citation.date}`
 }
 
-export function getLongCitation(slug){
+export function getLongCitation(slug) {
   const citation = getCitation(slug)
 
   return (
@@ -21,10 +21,8 @@ export function getLongCitation(slug){
   )
 }
 
-function getCitation(slug){
-  const citation = sourceCitations.filter(
-    c => c.slug === slug
-  )
+function getCitation(slug) {
+  const citation = sourceCitations.filter(c => c.slug === slug)
   return citation[0]
 }
 
@@ -34,47 +32,49 @@ const sourceCitations = [
     title: "Climate Watch - U.S. States Greenhouse Gas Emissions 1990 to 2018",
     source: "World Resource Institute",
     source_short: "WRI",
-    date: "Mar 2021", 
-    link: "https://datasets.wri.org/dataset/climate-watch-states-greenhouse-gas-emissions"
+    date: "Mar 2021",
+    link:
+      "https://datasets.wri.org/dataset/climate-watch-states-greenhouse-gas-emissions",
   },
   {
     slug: "building-footprints",
     title: "U.S. Building Footprints",
     source: "Microsoft Maps",
     source_short: "Microsoft",
-    date: "Mar 2021", 
-    link: "https://github.com/microsoft/USBuildingFootprints"
+    date: "Mar 2021",
+    link: "https://github.com/microsoft/USBuildingFootprints",
   },
   {
     slug: "building-energy",
     title: "U.S. Building Stock Characterization Study",
     source: "The National Renewable Energy Laboratory (NREL)",
     source_short: "NREL",
-    date: "Dec 2021", 
-    link: "https://www.nrel.gov/docs/fy22osti/83063.pdf"
+    date: "Dec 2021",
+    link: "https://www.nrel.gov/docs/fy22osti/83063.pdf",
   },
   {
     slug: "vehicles",
     title: "State Motor-Vehicle Registrations",
     source: "U.S. Department of Transportation",
     source_short: "DOT",
-    date: "Feb 2021", 
-    link: "https://www.fhwa.dot.gov/policyinformation/statistics/2017/mv1.cfm"
+    date: "Feb 2021",
+    link: "https://www.fhwa.dot.gov/policyinformation/statistics/2017/mv1.cfm",
   },
   {
     slug: "power-plants",
     title: "Environmental Justice Screening and Mapping Tool (EJScreen)",
     source: "U.S. Environmental Protection Agency (EPA)",
     source_short: "EPA",
-    date: "Jan 2021", 
-    link: "https://www.epa.gov/airmarkets/power-plants-and-neighboring-communities#mapping"
+    date: "Jan 2021",
+    link:
+      "https://www.epa.gov/airmarkets/power-plants-and-neighboring-communities#mapping",
   },
   {
     slug: "power-generation",
     title: "Electric generation by source 2001-2021",
     source: "U.S. Energy Information Administration (EIA)",
     source_short: "EIA",
-    date: "Apr 2022", 
-    link: "https://www.eia.gov/opendata/v1/qb.php?category=1"
+    date: "Apr 2022",
+    link: "https://www.eia.gov/opendata/v1/qb.php?category=1",
   },
 ]

--- a/src/constants/source-citations.js
+++ b/src/constants/source-citations.js
@@ -1,0 +1,80 @@
+import React from "react"
+
+export function getShortCitation(slug){
+  const citation = getCitation(slug)
+  return `${citation.source_short}, ${citation.date}`
+}
+
+export function getLongCitation(slug){
+  const citation = getCitation(slug)
+
+  return (
+    <p>
+      <a className="font-weight-bold" href={citation.link}>
+        {citation.title}
+      </a>
+      <br />
+      {citation.source}
+      <br />
+      {citation.date}
+    </p>
+  )
+}
+
+function getCitation(slug){
+  const citation = sourceCitations.filter(
+    c => c.slug === slug
+  )
+  return citation[0]
+}
+
+const sourceCitations = [
+  {
+    slug: "emissions",
+    title: "Climate Watch - U.S. States Greenhouse Gas Emissions 1990 to 2018",
+    source: "World Resource Institute",
+    source_short: "WRI",
+    date: "Mar 2021", 
+    link: "https://datasets.wri.org/dataset/climate-watch-states-greenhouse-gas-emissions"
+  },
+  {
+    slug: "building-footprints",
+    title: "U.S. Building Footprints",
+    source: "Microsoft Maps",
+    source_short: "Microsoft",
+    date: "Mar 2021", 
+    link: "https://github.com/microsoft/USBuildingFootprints"
+  },
+  {
+    slug: "building-energy",
+    title: "U.S. Building Stock Characterization Study",
+    source: "The National Renewable Energy Laboratory (NREL)",
+    source_short: "NREL",
+    date: "Dec 2021", 
+    link: "https://www.nrel.gov/docs/fy22osti/83063.pdf"
+  },
+  {
+    slug: "vehicles",
+    title: "State Motor-Vehicle Registrations",
+    source: "U.S. Department of Transportation",
+    source_short: "DOT",
+    date: "Feb 2021", 
+    link: "https://www.fhwa.dot.gov/policyinformation/statistics/2017/mv1.cfm"
+  },
+  {
+    slug: "power-plants",
+    title: "Environmental Justice Screening and Mapping Tool (EJScreen)",
+    source: "U.S. Environmental Protection Agency (EPA)",
+    source_short: "EPA",
+    date: "Jan 2021", 
+    link: "https://www.epa.gov/airmarkets/power-plants-and-neighboring-communities#mapping"
+  },
+  {
+    slug: "power-generation",
+    title: "Electric generation by source 2001-2021",
+    source: "U.S. Energy Information Administration (EIA)",
+    source_short: "EIA",
+    date: "Apr 2022", 
+    link: "https://www.eia.gov/opendata/v1/qb.php?category=1"
+  },
+]

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -266,7 +266,7 @@ const AboutPage = ({ data }) => {
               className="font-weight-bold"
               href="https://datasets.wri.org/dataset/climate-watch-states-greenhouse-gas-emissions"
             >
-              Climate Watch - U.S. States Greenhouse Gas Emissions
+              Climate Watch - U.S. States Greenhouse Gas Emissions 1990 to 2018
             </a>
             <br />
             World Resources Institute

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -262,23 +262,18 @@ const AboutPage = ({ data }) => {
             of this open source project.
           </p>
           <h3 className="pt-2 h4">U.S. Emissions By State</h3>
-          { getLongCitation("emissions") }
-          
+          {getLongCitation("emissions")}
           <h3 className="pt-2 h4">
             U.S. Building Footprints And Electrification
           </h3>
-          { getLongCitation("building-footprints") }
-          { getLongCitation("building-energy") }
-          
+          {getLongCitation("building-footprints")}
+          {getLongCitation("building-energy")}
           <h3 className="pt-2 h4">Vehicles By State</h3>
-          { getLongCitation("vehicles") }
-
+          {getLongCitation("vehicles")}
           <h3 className="pt-2 h4">Power Plants By State</h3>
-          { getLongCitation("power-plants") }
-
+          {getLongCitation("power-plants")}
           <h3 className="pt-2 h4">State Renewable Generation Targets</h3>
-          { getLongCitation("power-generation") }
-
+          {getLongCitation("power-generation")}
           <h2 className="pt-3">Code</h2>
           <p>
             All the code for this site is open source and available on{" "}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -5,6 +5,7 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import SingleBarChart from "../components/singlebar"
 import { getLatestUsData } from "../components/getLatestEmissions"
+import { getLongCitation } from "../constants/source-citations.js"
 
 const getCleanData = data => {
   let mutableDataObj = {}
@@ -261,84 +262,23 @@ const AboutPage = ({ data }) => {
             of this open source project.
           </p>
           <h3 className="pt-2 h4">U.S. Emissions By State</h3>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://datasets.wri.org/dataset/climate-watch-states-greenhouse-gas-emissions"
-            >
-              Climate Watch - U.S. States Greenhouse Gas Emissions 1990 to 2018
-            </a>
-            <br />
-            World Resources Institute
-            <br />
-            March 23, 2021
-          </p>
+          { getLongCitation("emissions") }
+          
           <h3 className="pt-2 h4">
             U.S. Building Footprints And Electrification
           </h3>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://github.com/microsoft/USBuildingFootprints"
-            >
-              U.S. Building Footprints
-            </a>
-            <br />
-            Microsoft Maps
-            <br />
-            Mar 27, 2021
-          </p>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://www.nrel.gov/docs/fy22osti/83063.pdf"
-            >
-              U.S. Building Stock Characterization Study
-            </a>
-            <br />
-            The National Renewable Energy Laboratory (NREL)
-            <br />
-            Dec 2021
-          </p>
+          { getLongCitation("building-footprints") }
+          { getLongCitation("building-energy") }
+          
           <h3 className="pt-2 h4">Vehicles By State</h3>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://www.fhwa.dot.gov/policyinformation/statistics/2017/mv1.cfm"
-            >
-              State Motor-Vehicle Registrations
-            </a>
-            <br />
-            U.S. Department of Transportation
-            <br />
-            Feb 2021
-          </p>
+          { getLongCitation("vehicles") }
+
           <h3 className="pt-2 h4">Power Plants By State</h3>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://www.epa.gov/airmarkets/power-plants-and-neighboring-communities#mapping"
-            >
-              Environmental Justice Screening and Mapping Tool (EJScreen)
-            </a>
-            <br />
-            U.S. Environmental Protection Agency (EPA)
-            <br />
-            Jan 27, 2021
-          </p>
+          { getLongCitation("power-plants") }
+
           <h3 className="pt-2 h4">State Renewable Generation Targets</h3>
-          <p>
-            <a
-              className="font-weight-bold"
-              href="https://www.eia.gov/opendata/v1/qb.php?category=1"
-            >
-              Electric generation by source 2001-2021
-            </a>
-            <br />
-            U.S. Energy Information Administration (EIA)
-            <br />
-            Updated Apr 2022
-          </p>
+          { getLongCitation("power-generation") }
+
           <h2 className="pt-3">Code</h2>
           <p>
             All the code for this site is open source and available on{" "}


### PR DESCRIPTION
## Overview

Adds "Source" citations to the home page map, as well as for the charts on the state detail pages.

Closes #132 

### Demo

<img width="1302" alt="Screen Shot 2022-10-10 at 10 03 40 PM" src="https://user-images.githubusercontent.com/919583/194987926-6707271f-c225-4e26-9aaf-e721132bdbf2.png">
<img width="1483" alt="Screen Shot 2022-10-10 at 10 06 09 PM" src="https://user-images.githubusercontent.com/919583/194987930-eb3aeeab-e1ee-4049-bcf7-0025ba268250.png">


## Testing Instructions

- view the home page and confirm you see the source below the map legend
- on the state detail page, confirm you see the source for emissions over time, the emissions breakdown on the left, and under each of the smaller bar charts for each section
- confirm it looks good on mobile as well
