### PR TITLE
Add Tooltip for Induction Stoves & Heat Pumps

### DIFF
--- a/src/components/state-details.js
+++ b/src/components/state-details.js
@@ -453,23 +453,11 @@ export default function StateDetailsPage({ location, data }) {
               <ul className="h4">
                 <li>
                   Boilers and furnaces with{" "}
-                  <a
-                    href="https://en.wikipedia.org/wiki/Heat_pump"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    heat pumps
-                  </a>
+                  <strong>{getTerminologyHover("heat-pumps")}</strong>
                 </li>
                 <li>
                   Gas stoves with{" "}
-                  <a
-                    href="https://en.wikipedia.org/wiki/Induction_cooking"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    electric induction ranges
-                  </a>
+                  <strong>{getTerminologyHover("induction-stoves")}</strong>
                 </li>
               </ul>
             </div>

--- a/src/constants/terminology-list.js
+++ b/src/constants/terminology-list.js
@@ -76,13 +76,13 @@ export const terminologyDefs = [
   {
     slug: "heat-pumps",
     term: 'heat pumps',
-    definition: 'Heat pumps are electric appliances that can heat and cool a building using the refrigiration cycle, acting like reversible air conditioners.',
+    definition: 'Heat pumps are electric appliances that can heat and cool a building using the refrigeration cycle, acting like reversible air conditioners.',
   },
   {
     slug: "induction-stoves",
     term: 'electric induction stoves',
-    definition: 'Induction stoves are type of electric stove that uses magnets to create heat directly within pots or pans. These ' +
-      'are distinct from radiant electric stoves (which glow red) because they heat up and cool down immediately and don\'t stay hot after use.',
+    definition: 'Induction stoves are a type of electric stove that use magnets to create heat directly within pots or pans. These ' +
+      'are distinct from radiant electric stoves (which glow red) because they heat up and cool down immediately and don\'t stay hot after use!',
   },
   {
     slug: "geothermal-energy",

--- a/src/constants/terminology-list.js
+++ b/src/constants/terminology-list.js
@@ -75,14 +75,16 @@ export const terminologyDefs = [
   },
   {
     slug: "heat-pumps",
-    term: 'heat pumps',
-    definition: 'Heat pumps are electric appliances that can heat and cool a building using the refrigeration cycle, acting like reversible air conditioners.',
+    term: "heat pumps",
+    definition:
+      "Heat pumps are electric appliances that can heat and cool a building using the refrigeration cycle, acting like reversible air conditioners.",
   },
   {
     slug: "induction-stoves",
-    term: 'electric induction stoves',
-    definition: 'Induction stoves are a type of electric stove that use magnets to create heat directly within pots or pans. These ' +
-      'are distinct from radiant electric stoves (which glow red) because they heat up and cool down immediately and don\'t stay hot after use!',
+    term: "electric induction stoves",
+    definition:
+      "Induction stoves are a type of electric stove that use magnets to create heat directly within pots or pans. These " +
+      "are distinct from radiant electric stoves (which glow red) because they heat up and cool down immediately and don't stay hot after use!",
   },
   {
     slug: "geothermal-energy",

--- a/src/constants/terminology-list.js
+++ b/src/constants/terminology-list.js
@@ -11,6 +11,9 @@ export function getTerminologyLink(slug) {
   )
 }
 
+/**
+ * Return a term phrase with a ? icon that shows a tooltip explaining the term
+ */
 export function getTerminologyHover(slug) {
   const t = getTerminology(slug)
   if (!t) {
@@ -71,6 +74,17 @@ export const terminologyDefs = [
     definition: `To move away from carbon producing appliances and machines.`,
   },
   {
+    slug: "heat-pumps",
+    term: 'heat pumps',
+    definition: 'Heat pumps are electric appliances that can heat and cool a building using the refrigiration cycle, acting like reversible air conditioners.',
+  },
+  {
+    slug: "induction-stoves",
+    term: 'electric induction stoves',
+    definition: 'Induction stoves are type of electric stove that uses magnets to create heat directly within pots or pans. These ' +
+      'are distinct from radiant electric stoves (which glow red) because they heat up and cool down immediately and don\'t stay hot after use.',
+  },
+  {
     slug: "geothermal-energy",
     term: "geothermal energy",
     definition: `The natural heat emanating from the Earth’s core being conveyed by either magma or water to the Earth’s surface where it can be converted to electricity or used for heating.`,
@@ -88,7 +102,7 @@ export const terminologyDefs = [
   {
     slug: "megawatt",
     term: "megawatt (MW)",
-    definition: `A unit of energy. One megawatt can power 400-900 homes a year.`,
+    definition: `A unit of electric power. A one megawatt power generator can power around 400-900 homes a year.`,
   },
   {
     slug: "mtco2e",

--- a/src/pages/faq.js
+++ b/src/pages/faq.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
@@ -62,7 +63,7 @@ const FAQ = () => {
         </ol>
         <p>
           Ready to do something in your state?{" "}
-          <a href="do-something">Get started here</a>.
+          <Link to="/take-action">Get started here</Link>.
         </p>
         <h3>
           Why do you only focus on wind and solar power? Is that reliable?

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -55,6 +55,9 @@
   padding: 0.5rem 1rem;
 }
 
+/** Make sure focusing links works with both sticky headers */
+.state-details-main * { scroll-margin-top: 15rem; }
+
 /**
  * Set consistent paragraph styles to keep text size uniform unless a paragraph
  * specifically should be bigger or smaller

--- a/src/styles/state-details.css
+++ b/src/styles/state-details.css
@@ -56,7 +56,9 @@
 }
 
 /** Make sure focusing links works with both sticky headers */
-.state-details-main * { scroll-margin-top: 15rem; }
+.state-details-main * {
+  scroll-margin-top: 15rem;
+}
 
 /**
  * Set consistent paragraph styles to keep text size uniform unless a paragraph


### PR DESCRIPTION
## Overview

In one of my user interviews a user didn't know what an induction range is or what a heat pump was, and the Wikipedia links we used before were a bit much and take folks out of the flow. I moved these two appliances into the terminology list - here's a demo (the text has been updated since this GIF though):

![Peek 2023-01-22 17-58](https://user-images.githubusercontent.com/3187531/213947499-344edb33-bbee-43c2-90e5-40b17c58622a.gif)

Also fixed a bug where focusing the new terminology tooltips sometimes being off screen because of the double sticky header. You can test this by tabbing down to the wind power source (try clicking down on the link, moving your mouse off, and letting go of the mouse to move focus more quickly) and then using Shift + Tab to go back one tabbable element:

| Before | After |
| --- | --- |
| ![Screenshot from 2023-01-22 17-57-54](https://user-images.githubusercontent.com/3187531/213947547-0dd70fd1-2ed0-4bfb-bf0f-895395a526ed.png) | ![Screenshot from 2023-01-22 17-58-17](https://user-images.githubusercontent.com/3187531/213947550-6f4e59e6-99ba-4eca-ab08-65267782e238.png) |

### Demo

See Overview.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

- Confirm new tooltips work properly on desktop and mobile
- Validate that tabbing through the entire state details page works well, with visible focus